### PR TITLE
Fix incorrectly time zoned default date header in new messages.

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -84,7 +84,7 @@ const string message::MIME_VERSION_HEADER{"MIME-Version"};
 message::message() : mime()
 {
     time_zone_ptr tz(new posix_time_zone("00:00"));
-    _date_time = make_shared<local_date_time>(second_clock::local_time(), tz);
+    _date_time = make_shared<local_date_time>(second_clock::universal_time(), tz);
 }
 
 


### PR DESCRIPTION
second_clock::local_time() gives the time in local time, but the used constructor of local_date_time with a timezone assumes the time to be UTC, which means the resulting time will be off by the original offset of the time zone.

(for example when sending emails from Germany the receiving email clients claimed the emails to be from 2 hours in the future)