### PR TITLE
Use std::random instead of Boost.Random

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Mailio library is supposed to work on all platforms supporting C++ 11 compiler, 
 For Linux the following configuration is tested:
 
 * gcc 7.3.0.
-* Boost 1.66 with Regex, Date Time, Random available.
+* Boost 1.66 with Regex, Date Time available.
 * POSIX Threads, OpenSSL and Crypto libraries available on the system.
 * CMake 3.11
 

--- a/cmake/req.cmake
+++ b/cmake/req.cmake
@@ -2,6 +2,6 @@
 if(WIN32)
     SET(Boost_USE_STATIC_LIBS ON)
 endif(WIN32)
-find_package(Boost REQUIRED COMPONENTS system date_time regex random)
+find_package(Boost REQUIRED COMPONENTS system date_time regex)
 
 find_package(OpenSSL)

--- a/src/mime.cpp
+++ b/src/mime.cpp
@@ -16,8 +16,7 @@ copy at http://www.freebsd.org/copyright/freebsd-license.html.
 #include <sstream>
 #include <map>
 #include <vector>
-#include <boost/random/random_device.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
+#include <random>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <mailio/base64.hpp>
@@ -904,8 +903,8 @@ string mime::make_boundary() const
 {
     string bound;
     bound.reserve(10);
-    boost::random::random_device rng;
-    boost::random::uniform_int_distribution<> index_dist(0, codec::HEX_DIGITS.size() - 1);
+    std::random_device rng;
+    std::uniform_int_distribution<> index_dist(0, codec::HEX_DIGITS.size() - 1);
     for (int i = 0; i < 10; i++)
         bound += codec::HEX_DIGITS[index_dist(rng)];
     return "-------" + bound;


### PR DESCRIPTION
Since you're requiring c++11 there's no point in prefering Boost.Random over std::random IMO.

Notice: I only tested if it compiles under Windows with msvc2017. I didn't actually run any code.

If it is ok, I'll do the same for Boost.Regex and std::regex