### PR TITLE
Replaced asio deprecated entities

### DIFF
--- a/include/mailio/dialog.hpp
+++ b/include/mailio/dialog.hpp
@@ -156,7 +156,7 @@ protected:
     /**
     Asio input/output service.
     **/
-    std::unique_ptr<boost::asio::io_service> _ios;
+    std::unique_ptr<boost::asio::io_context> _ios;
 
     /**
     Socket connection.


### PR DESCRIPTION
Good day and thank you for your library!

We'd like to use it in our company, but we use boost with BOOST_ASIO_NO_DEPRECATED define and your implementation uses the old variants of asio entites. So I fixed it and hope you will fix it too.