### PR TITLE
Gen a .pc file. Inst dir overrides. Support GNUInstallDirs. Fix inst paths.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,46 @@ project(mailio VERSION 0.17.0)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(NOT DEFINED LIB_SUFFIX)
+  set(LIB_SUFFIX "" CACHE STRING "Suffix for installed library path. Ex. 64 for lib64")
+endif(NOT DEFINED LIB_SUFFIX)
+
+# Set bindir, if not use -DBIN_INSTALL_DIR
+if(NOT BIN_INSTALL_DIR)
+  if(CMAKE_INSTALL_BINDIR)
+    set(BIN_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+  else(CMAKE_INSTALL_BINDIR)
+    set(BIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/bin")
+  endif(CMAKE_INSTALL_BINDIR)
+endif(NOT BIN_INSTALL_DIR)
+
+# Set libdir, if not use -DLIB_INSTALL_DIR
+if(NOT LIB_INSTALL_DIR)
+  if(CMAKE_INSTALL_LIBDIR)
+    set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+  else(CMAKE_INSTALL_LIBDIR)
+    set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
+  endif(CMAKE_INSTALL_LIBDIR)
+endif(NOT LIB_INSTALL_DIR)
+
+# Set includedir, if not use -DINCLUDE_INSTALL_DIR
+if(NOT INCLUDE_INSTALL_DIR)
+  if(CMAKE_INSTALL_INCLUDEDIR)
+    set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+  else(CMAKE_INSTALL_INCLUDEDIR)
+    set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include")
+  endif(CMAKE_INSTALL_INCLUDEDIR)
+endif(NOT INCLUDE_INSTALL_DIR)
+
+# Set sharedir, if not use -DSHARE_INSTALL_DIR
+if(NOT SHARE_INSTALL_DIR)
+  if(CMAKE_INSTALL_DATADIR)
+    set(SHARE_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}")
+  else(CMAKE_INSTALL_DATADIR)
+    set(SHARE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share")
+  endif(CMAKE_INSTALL_DATADIR)
+endif(NOT SHARE_INSTALL_DIR)
+
 # options for mailio to control how the project is built.
 option(MAILIO_BUILD_SHARED_LIBRARY "Turn on to build mailio as a shared library." ON)
 option(MAILIO_BUILD_DOCUMENTATION "Turn on to build doxygen based documentation." ON)
@@ -20,6 +60,8 @@ endif(WIN32)
 find_package(Boost REQUIRED COMPONENTS system date_time regex)
 find_package(OpenSSL)
 set(CMAKE_THREAD_PREFER_PTHREAD)
+# "Use of both the imported target as well as this switch is highly recommended for new code."
+set(THREADS_PREFER_PTHREAD_FLAG) 
 find_package(Threads)
 
 set(project_sources 
@@ -78,6 +120,27 @@ set(BUILD_SHARED_LIBS ${MAILIO_BUILD_SHARED_LIBRARY})
 
 add_library(${PROJECT_NAME} ${project_sources} ${project_headers})
 
+
+# pkg-config support
+set(prefix "${CMAKE_INSTALL_PREFIX}")
+set(exec_prefix "\${prefix}" )
+
+if(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
+  set(libdir "${LIB_INSTALL_DIR}")
+else(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
+  set(libdir "\${exec_prefix}/${LIB_INSTALL_DIR}")
+endif(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
+
+if(IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}")
+  set(includedir "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
+else(IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}")
+  set(includedir "\${prefix}/${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
+endif(IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}")
+
+configure_file(mailio.pc.in ${CMAKE_BINARY_DIR}/mailio.pc IMMEDIATE @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/mailio.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+
+
 # generate the export header for exporting symbols
 # this is needed to generate a shared library.
 include(GenerateExportHeader)
@@ -87,7 +150,7 @@ target_include_directories(${PROJECT_NAME}
         "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}>"
         "$<INSTALL_INTERFACE:include>"
 )
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/export.hpp DESTINATION include/mailio)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/export.hpp DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
 
 if(Boost_FOUND)
     target_include_directories(${PROJECT_NAME} PUBLIC ${Boost_INCLUDE_DIRS})
@@ -99,19 +162,17 @@ if(OPENSSL_FOUND)
     target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
 endif()
 
-# install the project headers
-install(DIRECTORY include/mailio DESTINATION include)
+install(DIRECTORY include/mailio DESTINATION ${INCLUDE_INSTALL_DIR})
 
-# install the mailio library.
 install(TARGETS ${PROJECT_NAME}
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+    RUNTIME DESTINATION ${BIN_INSTALL_DIR}
 )
 
 # optionally build examples
 if(${MAILIO_BUILD_EXAMPLES})
     add_subdirectory(examples)
     file(GLOB PNGS "${PROJECT_SOURCE_DIR}/examples/*.png")
-    install(FILES ${PNGS} DESTINATION examples/)
+    install(FILES ${PNGS} DESTINATION "${SHARE_INSTALL_DIR}/${PROJECT_NAME}/examples/")
 endif(${MAILIO_BUILD_EXAMPLES})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,7 +3,7 @@ function(add_mailio_example SOURCE_FILE)
     get_filename_component(file_name ${SOURCE_FILE} NAME_WE)
     add_executable(${file_name} ${SOURCE_FILE})
     target_link_libraries(${file_name} PUBLIC mailio ${CMAKE_THREAD_LIBS_INIT})
-    install(TARGETS ${file_name} DESTINATION examples)
+    install(TARGETS ${file_name} DESTINATION "${SHARE_INSTALL_DIR}/${PROJECT_NAME}/examples")
 endfunction(add_mailio_example)
 
 # find all the example files.

--- a/mailio.pc.in
+++ b/mailio.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+sharedlibdir=@libdir@
+includedir=@includedir@
+
+Name: mailio
+Description: Cross-platform MIME library for SMTP, POP3, and IMAP protocols
+Version: @PROJECT_VERSION@
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -lmailio
+Cflags: -I${includedir}
+ 


### PR DESCRIPTION
Awesome library, thanks so much for this real hidden gem!
I wish you success with it. It works for me.

Here's my contribution if you like. May want to edit for content or variable naming.

Generate a pkgconfig *.pc file.
Allow installation directory overrides and support CMake GNUInstallDirs.
Fixup most installation paths **except** the docs. I left that part alone since I didn't generate any here.

Wish / possible future work: More login auth types?