### PR TITLE
Tim's full working library pull request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,46 @@ project(mailio VERSION 0.17.0)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(NOT DEFINED LIB_SUFFIX)
+  set(LIB_SUFFIX "" CACHE STRING "Suffix for installed library path. Ex. 64 for lib64")
+endif(NOT DEFINED LIB_SUFFIX)
+
+# Set bindir, if not use -DBIN_INSTALL_DIR
+if(NOT BIN_INSTALL_DIR)
+  if(CMAKE_INSTALL_BINDIR)
+    set(BIN_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+  else(CMAKE_INSTALL_BINDIR)
+    set(BIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/bin")
+  endif(CMAKE_INSTALL_BINDIR)
+endif(NOT BIN_INSTALL_DIR)
+
+# Set libdir, if not use -DLIB_INSTALL_DIR
+if(NOT LIB_INSTALL_DIR)
+  if(CMAKE_INSTALL_LIBDIR)
+    set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+  else(CMAKE_INSTALL_LIBDIR)
+    set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
+  endif(CMAKE_INSTALL_LIBDIR)
+endif(NOT LIB_INSTALL_DIR)
+
+# Set includedir, if not use -DINCLUDE_INSTALL_DIR
+if(NOT INCLUDE_INSTALL_DIR)
+  if(CMAKE_INSTALL_INCLUDEDIR)
+    set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+  else(CMAKE_INSTALL_INCLUDEDIR)
+    set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include")
+  endif(CMAKE_INSTALL_INCLUDEDIR)
+endif(NOT INCLUDE_INSTALL_DIR)
+
+# Set sharedir, if not use -DSHARE_INSTALL_DIR
+if(NOT SHARE_INSTALL_DIR)
+  if(CMAKE_INSTALL_DATADIR)
+    set(SHARE_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}")
+  else(CMAKE_INSTALL_DATADIR)
+    set(SHARE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share")
+  endif(CMAKE_INSTALL_DATADIR)
+endif(NOT SHARE_INSTALL_DIR)
+
 # options for mailio to control how the project is built.
 option(MAILIO_BUILD_SHARED_LIBRARY "Turn on to build mailio as a shared library." ON)
 option(MAILIO_BUILD_DOCUMENTATION "Turn on to build doxygen based documentation." ON)
@@ -20,6 +60,8 @@ endif(WIN32)
 find_package(Boost REQUIRED COMPONENTS system date_time regex)
 find_package(OpenSSL)
 set(CMAKE_THREAD_PREFER_PTHREAD)
+# "Use of both the imported target as well as this switch is highly recommended for new code."
+set(THREADS_PREFER_PTHREAD_FLAG) 
 find_package(Threads)
 
 set(project_sources 
@@ -78,6 +120,27 @@ set(BUILD_SHARED_LIBS ${MAILIO_BUILD_SHARED_LIBRARY})
 
 add_library(${PROJECT_NAME} ${project_sources} ${project_headers})
 
+
+# pkg-config support
+set(prefix "${CMAKE_INSTALL_PREFIX}")
+set(exec_prefix "\${prefix}" )
+
+if(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
+  set(libdir "${LIB_INSTALL_DIR}")
+else(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
+  set(libdir "\${exec_prefix}/${LIB_INSTALL_DIR}")
+endif(IS_ABSOLUTE "${LIB_INSTALL_DIR}")
+
+if(IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}")
+  set(includedir "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
+else(IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}")
+  set(includedir "\${prefix}/${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
+endif(IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}")
+
+configure_file(mailio.pc.in ${CMAKE_BINARY_DIR}/mailio.pc IMMEDIATE @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/mailio.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+
+
 # generate the export header for exporting symbols
 # this is needed to generate a shared library.
 include(GenerateExportHeader)
@@ -87,7 +150,7 @@ target_include_directories(${PROJECT_NAME}
         "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}>"
         "$<INSTALL_INTERFACE:include>"
 )
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/export.hpp DESTINATION include/mailio)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/export.hpp DESTINATION "${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
 
 if(Boost_FOUND)
     target_include_directories(${PROJECT_NAME} PUBLIC ${Boost_INCLUDE_DIRS})
@@ -99,19 +162,17 @@ if(OPENSSL_FOUND)
     target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
 endif()
 
-# install the project headers
-install(DIRECTORY include/mailio DESTINATION include)
+install(DIRECTORY include/mailio DESTINATION ${INCLUDE_INSTALL_DIR})
 
-# install the mailio library.
 install(TARGETS ${PROJECT_NAME}
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+    RUNTIME DESTINATION ${BIN_INSTALL_DIR}
 )
 
 # optionally build examples
 if(${MAILIO_BUILD_EXAMPLES})
     add_subdirectory(examples)
     file(GLOB PNGS "${PROJECT_SOURCE_DIR}/examples/*.png")
-    install(FILES ${PNGS} DESTINATION examples/)
+    install(FILES ${PNGS} DESTINATION "${SHARE_INSTALL_DIR}/${PROJECT_NAME}/examples/")
 endif(${MAILIO_BUILD_EXAMPLES})

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
+27.03.2019 
+ - imap::statistics() method: Add optional unseen, uidnext, uidvalidity flags. (terminator356)
+
 26.03.2019 
  - Add imap fetch_messages method. (terminator356)
- 
+
 12.03.2019 
  * From github user terminator356:
  - Fix exception on lower case letters: "Bad hexadecimal digit" in quoted_printable::decode().

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+26.03.2019 
+ - Add imap fetch_messages method. (terminator356)
+ 
 12.03.2019 
  * From github user terminator356:
  - Fix exception on lower case letters: "Bad hexadecimal digit" in quoted_printable::decode().

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,15 @@
+12.03.2019 
+ * From github user terminator356:
+ - Fix exception on lower case letters: "Bad hexadecimal digit" in quoted_printable::decode().
+   Convert the two characters to uppercase before checking.
+ - Complete mailbox_stat_t statistics: messages_recent, messages_first_unseen,
+    uidnext, uidvalidity. This REALLY helps with client message caching.
+ - Add several new commands in imap.hpp, several do not select() first, for speed:
+    mailbox_stat_t select_mailbox(): Exposes the protected select().
+    mailbox_stat_t examine_mailbox(): Examine a mailbox.
+    void fetch_message(): Has 'is_uid' parameter meaning 'message_no' param is a uid.
+    void remove_message(): Has 'is_uid' parameter meaning 'message_no' param is a uid.
+    void search_messages(): Has 'want_uids' parameter meaning return uids.
+ - Add a new line_len_policy_t value: VERYLARGE = 16384. Required for certain received messages.
+ - Add a separate '_decoder_line_policy' besides '_line_policy' to all objects.
+   This allows a separate very large decoding policy while keeping a standard encoding policy.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,7 +3,7 @@ function(add_mailio_example SOURCE_FILE)
     get_filename_component(file_name ${SOURCE_FILE} NAME_WE)
     add_executable(${file_name} ${SOURCE_FILE})
     target_link_libraries(${file_name} PUBLIC mailio ${CMAKE_THREAD_LIBS_INIT})
-    install(TARGETS ${file_name} DESTINATION examples)
+    install(TARGETS ${file_name} DESTINATION "${SHARE_INSTALL_DIR}/${PROJECT_NAME}/examples")
 endfunction(add_mailio_example)
 
 # find all the example files.

--- a/examples/pop3s_attachment.cpp
+++ b/examples/pop3s_attachment.cpp
@@ -41,8 +41,6 @@ int main()
         // mail message to store the fetched one
         message msg;
         // set the line policy to mandatory, so longer lines could be parsed
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         msg.line_policy(codec::line_len_policy_t::MANDATORY);
         msg.line_policy(codec::line_len_policy_t::RECOMMENDED, codec::line_len_policy_t::MANDATORY);
 
         // use a server with SSL connectivity

--- a/examples/pop3s_attachment.cpp
+++ b/examples/pop3s_attachment.cpp
@@ -41,7 +41,9 @@ int main()
         // mail message to store the fetched one
         message msg;
         // set the line policy to mandatory, so longer lines could be parsed
-        msg.line_policy(codec::line_len_policy_t::MANDATORY);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         msg.line_policy(codec::line_len_policy_t::MANDATORY);
+        msg.line_policy(codec::line_len_policy_t::RECOMMENDED, codec::line_len_policy_t::MANDATORY);
 
         // use a server with SSL connectivity
         pop3s conn("pop3.mailserver.com", 995);

--- a/examples/pop3s_fetch_one.cpp
+++ b/examples/pop3s_fetch_one.cpp
@@ -35,7 +35,9 @@ int main()
         // mail message to store the fetched one
         message msg;
         // set the line policy to mandatory, so longer lines could be parsed
-        msg.line_policy(codec::line_len_policy_t::MANDATORY);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         msg.line_policy(codec::line_len_policy_t::MANDATORY);
+        msg.line_policy(codec::line_len_policy_t::RECOMMENDED, codec::line_len_policy_t::MANDATORY);
 
         // connect to server
         pop3s conn("pop.mail.yahoo.com", 995);

--- a/examples/pop3s_fetch_one.cpp
+++ b/examples/pop3s_fetch_one.cpp
@@ -35,8 +35,6 @@ int main()
         // mail message to store the fetched one
         message msg;
         // set the line policy to mandatory, so longer lines could be parsed
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         msg.line_policy(codec::line_len_policy_t::MANDATORY);
         msg.line_policy(codec::line_len_policy_t::RECOMMENDED, codec::line_len_policy_t::MANDATORY);
 
         // connect to server

--- a/include/mailio/base64.hpp
+++ b/include/mailio/base64.hpp
@@ -37,13 +37,6 @@ public:
     **/
     static const std::string CHARSET;
     
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Setting the line policy.
-// 
-//     @param line_policy Line length policy to set.
-//     **/
-//     base64(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
     Setting the encoder and decoder line policy.
 

--- a/include/mailio/base64.hpp
+++ b/include/mailio/base64.hpp
@@ -37,12 +37,21 @@ public:
     **/
     static const std::string CHARSET;
     
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Setting the line policy.
+// 
+//     @param line_policy Line length policy to set.
+//     **/
+//     base64(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
-    Setting the line policy.
+    Setting the encoder and decoder line policy.
 
-    @param line_policy Line length policy to set.
+    @param encoder_line_policy Encoder line length policy to set.
+    @param decoder_line_policy Decoder line length policy to set.
     **/
-    base64(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
+    base64(codec::line_len_policy_t encoder_line_policy = codec::line_len_policy_t::NONE,
+           codec::line_len_policy_t decoder_line_policy = codec::line_len_policy_t::NONE);
 
     base64(const base64&) = delete;
 

--- a/include/mailio/binary.hpp
+++ b/include/mailio/binary.hpp
@@ -30,13 +30,6 @@ class MAILIO_EXPORT binary : public codec
 {
 public:
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Setting the line policy.
-// 
-//     @param line_policy Line length policy to set.
-//     **/
-//     binary(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
     Setting the encoder and decoder line policy.
 

--- a/include/mailio/binary.hpp
+++ b/include/mailio/binary.hpp
@@ -30,12 +30,21 @@ class MAILIO_EXPORT binary : public codec
 {
 public:
 
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Setting the line policy.
+// 
+//     @param line_policy Line length policy to set.
+//     **/
+//     binary(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
-    Setting the line policy.
+    Setting the encoder and decoder line policy.
 
-    @param line_policy Line length policy to set.
+    @param encoder_line_policy Encoder line length policy to set.
+    @param decoder_line_policy Decoder line length policy to set.
     **/
-    binary(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
+    binary(codec::line_len_policy_t encoder_line_policy = codec::line_len_policy_t::NONE,
+           codec::line_len_policy_t decoder_line_policy = codec::line_len_policy_t::NONE);
 
     binary(const binary&) = delete;
 

--- a/include/mailio/bit7.hpp
+++ b/include/mailio/bit7.hpp
@@ -30,12 +30,21 @@ class MAILIO_EXPORT bit7 : public codec
 {
 public:
 
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Setting the line policy.
+// 
+//     @param line_policy Line policy to set.
+//     **/
+//     bit7(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
-    Setting the line policy.
+    Setting the encoder and decoder line policy.
 
-    @param line_policy Line policy to set.
+    @param encoder_line_policy Encoder line policy to set.
+    @param decoder_line_policy Decoder line policy to set.
     **/
-    bit7(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
+    bit7(codec::line_len_policy_t encoder_line_policy = codec::line_len_policy_t::NONE,
+         codec::line_len_policy_t decoder_line_policy = codec::line_len_policy_t::NONE);
 
     bit7(const bit7&) = delete;
 

--- a/include/mailio/bit7.hpp
+++ b/include/mailio/bit7.hpp
@@ -30,13 +30,6 @@ class MAILIO_EXPORT bit7 : public codec
 {
 public:
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Setting the line policy.
-// 
-//     @param line_policy Line policy to set.
-//     **/
-//     bit7(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
     Setting the encoder and decoder line policy.
 

--- a/include/mailio/bit8.hpp
+++ b/include/mailio/bit8.hpp
@@ -31,12 +31,21 @@ class MAILIO_EXPORT bit8 : public codec
 {
 public:
 
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Setting the line policy.
+// 
+//     @param line_policy Line policy to set.
+//     **/
+//     bit8(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
-    Setting the line policy.
+    Setting the encoder and decoder line policy.
 
-    @param line_policy Line policy to set.
+    @param encoder_line_policy Encoder line policy to set.
+    @param decoder_line_policy Decoder line policy to set.
     **/
-    bit8(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
+    bit8(codec::line_len_policy_t encoder_line_policy = codec::line_len_policy_t::NONE,
+         codec::line_len_policy_t decoder_line_policy = codec::line_len_policy_t::NONE);
 
     bit8(const bit8&) = delete;
 

--- a/include/mailio/bit8.hpp
+++ b/include/mailio/bit8.hpp
@@ -31,13 +31,6 @@ class MAILIO_EXPORT bit8 : public codec
 {
 public:
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Setting the line policy.
-// 
-//     @param line_policy Line policy to set.
-//     **/
-//     bit8(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
     Setting the encoder and decoder line policy.
 

--- a/include/mailio/codec.hpp
+++ b/include/mailio/codec.hpp
@@ -204,14 +204,24 @@ public:
 
     @todo No need for `SUBJECT` line policy.
     **/
-    enum class line_len_policy_t : std::string::size_type {NONE = 2048, RECOMMENDED = 78, MANDATORY = 998};
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     enum class line_len_policy_t : std::string::size_type {NONE = 2048, RECOMMENDED = 78, MANDATORY = 998};
+    enum class line_len_policy_t : std::string::size_type {NONE = 2048, RECOMMENDED = 78, MANDATORY = 998, VERYLARGE = 16384};
 
+    // REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Setting the line policy of the codec.
+// 
+//     @param line_policy Line policy to set.
+//     **/
+//     codec(line_len_policy_t line_policy);
     /**
-    Setting the line policy of the codec.
+    Setting the encoder and decoder line policy of the codec.
 
-    @param line_policy Line policy to set.
+    @param encoder_line_policy Encoder line policy to set.
+    @param decoder_line_policy Decoder line policy to set.
     **/
-    codec(line_len_policy_t line_policy);
+    codec(line_len_policy_t encoder_line_policy, line_len_policy_t decoder_line_policy);
 
     codec(const codec&) = delete;
 
@@ -242,11 +252,22 @@ public:
 
 protected:
 
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Line length policy.
+//     **/
+//     line_len_policy_t _line_policy;
     /**
-    Line length policy.
+    Encoder line length policy.
     **/
     line_len_policy_t _line_policy;
 
+    // REMOVE Tim. Added. We need a much larger value available for decoding since some emails tested were beyond 2048.
+    /**
+    Decoder line length policy.
+    **/
+    line_len_policy_t _decoder_line_policy;
+    
     /**
     Strict mode for encoding/decoding.
     **/

--- a/include/mailio/codec.hpp
+++ b/include/mailio/codec.hpp
@@ -204,17 +204,8 @@ public:
 
     @todo No need for `SUBJECT` line policy.
     **/
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     enum class line_len_policy_t : std::string::size_type {NONE = 2048, RECOMMENDED = 78, MANDATORY = 998};
     enum class line_len_policy_t : std::string::size_type {NONE = 2048, RECOMMENDED = 78, MANDATORY = 998, VERYLARGE = 16384};
 
-    // REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Setting the line policy of the codec.
-// 
-//     @param line_policy Line policy to set.
-//     **/
-//     codec(line_len_policy_t line_policy);
     /**
     Setting the encoder and decoder line policy of the codec.
 
@@ -252,17 +243,11 @@ public:
 
 protected:
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Line length policy.
-//     **/
-//     line_len_policy_t _line_policy;
     /**
     Encoder line length policy.
     **/
     line_len_policy_t _line_policy;
 
-    // REMOVE Tim. Added. We need a much larger value available for decoding since some emails tested were beyond 2048.
     /**
     Decoder line length policy.
     **/

--- a/include/mailio/imap.hpp
+++ b/include/mailio/imap.hpp
@@ -15,6 +15,8 @@ copy at http://www.freebsd.org/copyright/freebsd-license.html.
 
 #include <chrono>
 #include <list>
+// REMOVE Tim. Added.
+#include <map>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -243,6 +245,32 @@ public:
     **/
     void fetch_message(unsigned long message_no, message& msg, bool header_only = false, bool is_uid = false);
 
+    // REMOVE Tim. Added.
+    /**
+    Fetching messages from an already selected mailbox.
+
+    NOTE: fetch() selects the mailbox with every call, fetch_messages() does not.
+    A mailbox must already be selected before calling fetch_message().
+    Some servers report success if a message with the given number does not exist, so the method returns with the empty `msg`. Other considers
+    fetching non-existing message to be an error, and an exception is thrown.
+
+    @param message_nos String of message numbers or uids to fetch (ex. "1:4,5,6,7:10").
+    @param msgs        Map of messages to store the results, indexed by message number or uid.
+                       It does not clear the map first, so that results can be accumulated.
+    @param line_policy Decoder line policy to use while parsing each message.
+    @param header_only Flag if only the message headers should be fetched.
+    @param is_uids     Using message uid numbers instead of a message sequence numbers.
+    @throw imap_error  Fetching message failure.
+    @throw imap_error  Parsing failure.
+    @throw *           `parse_tag_result(const string&)`, `parse_response(const string&)`,
+                       `dialog::send(const string&)`, `dialog::receive()`, `message::parse(const string&, bool)`.
+    @todo              Add server error messages to exceptions.
+    **/
+    void fetch_messages(const std::string& message_nos,
+                        std::map<unsigned long /*message_number_or_uid*/, message>& msgs,
+                        codec::line_len_policy_t line_policy = codec::line_len_policy_t::RECOMMENDED,
+                        bool header_only = false, bool is_uids = false);
+
     /**
     Getting the mailbox statistics.
     
@@ -286,7 +314,8 @@ public:
     Searching a mailbox.
     
     @param keys        String of search keys.
-    @param result_list Store resulting list of indexes here.
+    @param result_list Store resulting list of message numbers or uids here.
+                       Does not clear the list first, so that results can be accumulated.
     @param want_uids   Return a list of message uids instead of message sequence numbers.
     @throw imap_error  Search mailbox failure.
     @throw imap_error  Parsing failure.

--- a/include/mailio/imap.hpp
+++ b/include/mailio/imap.hpp
@@ -225,15 +225,20 @@ public:
 
     /**
     Getting the mailbox statistics.
+    NOTE: The server might not support unseen, uidnext, or uidvalidity, which will cause an exception,
+           so those parameters are optional. 
     
-    @param mailbox    Mailbox name.
-    @return           Mailbox statistics.
-    @throw imap_error Parsing failure.
-    @throw imap_error Getting statistics failure.
-    @throw *          `parse_tag_result(const string&)`, `parse_response(const string&)`, `dialog::send(const string&)`, `dialog::receive()`.
-    @todo             Add server error messages to exceptions.
+    @param mailbox     Mailbox name.
+    @param unseen      Ask for the number of unseen messages.
+    @param uidnext     Ask for the next uid number.
+    @param uidvalidity Ask for the uidvalidity number.
+    @return            Mailbox statistics.
+    @throw imap_error  Parsing failure.
+    @throw imap_error  Getting statistics failure.
+    @throw *           `parse_tag_result(const string&)`, `parse_response(const string&)`, `dialog::send(const string&)`, `dialog::receive()`.
+    @todo              Add server error messages to exceptions.
     **/
-    mailbox_stat_t statistics(const std::string& mailbox);
+    mailbox_stat_t statistics(const std::string& mailbox, bool unseen = false, bool uidnext = false, bool uidvalidity = false);
 
     /**
     Removing a message from the given mailbox.

--- a/include/mailio/imap.hpp
+++ b/include/mailio/imap.hpp
@@ -15,7 +15,6 @@ copy at http://www.freebsd.org/copyright/freebsd-license.html.
 
 #include <chrono>
 #include <list>
-// REMOVE Tim. Added.
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -45,38 +44,11 @@ public:
     **/
     struct mailbox_stat_t
     {
-        // REMOVE Tim. Added.
-//         /**
-//           Some of these values were added in later versions. See RFC 3502 6.3.10
-//           The following flags indicate whether the values were detected.
-//         **/
-// 
-//         /**
-//         Whether the messages_unseen value is valid.
-//         **/
-//         bool unseen_valid;
-// 
-//         /**
-//         Whether the uidnext value is valid.
-//         **/
-//         bool uidnext_valid;
-// 
-//         /**
-//         Whether the uidvalidity value is valid.
-//         **/
-//         bool uidvalidity_valid;
-
-
-
         /**
         Number of messages in the mailbox.
         **/
         unsigned long messages_no;
 
-
-
-
-        // REMOVE Tim. Added.
         /**
         Number of recent messages in the mailbox.
         **/
@@ -106,17 +78,11 @@ public:
         **/
         unsigned long uidvalidity;
 
-
-
-
         /**
         Setting the number of messages to zero.
         **/
-        // REMOVE Tim. Changed.
-//          mailbox_stat_t() : messages_no(0)
         mailbox_stat_t()
-        : //unseen_valid(false), uidnext_valid(false), uidvalidity_valid(false),
-          messages_no(0), messages_recent(0), messages_unseen(0), messages_first_unseen(0),
+        : messages_no(0), messages_recent(0), messages_unseen(0), messages_first_unseen(0),
           uidnext(0), uidvalidity(0)
         {
         }
@@ -134,16 +100,6 @@ public:
     Available authentication methods.
     **/
     enum class auth_method_t {LOGIN};
-
-//     // REMOVE Tim. Added.
-//     /**
-//     Various options for commands. Can be ORd together.
-//     
-//     HeadersOnly: Fetch headers only, not full message text.
-//     WantUid:     Use message uids instead of message sequence numbers.
-//     **/
-//     enum command_option_t { NoOptions = 0x0, HeadersOnly = 0x1, WantUid = 0x2 };
-//     typedef unsigned int command_options_t;
 
     /**
     Creating a connection to a server.
@@ -180,7 +136,6 @@ public:
     **/
     void authenticate(const std::string& username, const std::string& password, auth_method_t method);
 
-    // REMOVE Tim. Added.
     /**
     Selecting a mailbox.
     
@@ -193,7 +148,6 @@ public:
     **/
     mailbox_stat_t select_mailbox(const std::list<std::string>& folder_name);
 
-    // REMOVE Tim. Added.
     /**
     Examining a mailbox.
 
@@ -224,7 +178,6 @@ public:
     **/
     void fetch(const std::string& mailbox, unsigned long message_no, message& msg, bool header_only = false);
 
-    // REMOVE Tim. Added.
     /**
     Fetching a message from an already selected mailbox.
 
@@ -245,7 +198,6 @@ public:
     **/
     void fetch_message(unsigned long message_no, message& msg, bool header_only = false, bool is_uid = false);
 
-    // REMOVE Tim. Added.
     /**
     Fetching messages from an already selected mailbox.
 
@@ -295,7 +247,6 @@ public:
     **/
     void remove(const std::string& mailbox, unsigned long message_no);
 
-    // REMOVE Tim. Added.
     /**
     Removing a message from an already selected mailbox.
     NOTE: remove() selects the mailbox with every call, remove_message() does not.
@@ -309,7 +260,6 @@ public:
     **/
     void remove_message(unsigned long message_no, bool is_uid = false);
 
-    // REMOVE Tim. Added.
     /**
     Searching a mailbox.
     
@@ -390,17 +340,6 @@ protected:
     **/
     void auth_login(const std::string& username, const std::string& password);
 
-    // REMOVE Tim. Changed.
-//     /**
-//     Selecting a mailbox.
-//     
-//     @param mailbox    Mailbox to select.
-//     @throw imap_error Selecting mailbox failure.
-//     @throw imap_error Parsing failure.
-//     @throw *          `parse_tag_result(const string&)`, `dialog::send(const string&)`, `dialog::receive()`.
-//     @todo             Add server error messages to exceptions.
-//     **/
-//     void select(const std::string& mailbox);
     /**
     Selecting a mailbox.
 
@@ -413,7 +352,6 @@ protected:
     **/
     mailbox_stat_t select(const std::string& mailbox);
 
-    // REMOVE Tim. Added.
     /**
     Examining a mailbox.
 
@@ -426,7 +364,6 @@ protected:
     **/
     mailbox_stat_t examine(const std::string& mailbox);
 
-    // REMOVE Tim. Added.
     /**
     Searching a mailbox.
     
@@ -450,7 +387,6 @@ protected:
     **/
     std::string folder_delimiter();
 
-    // REMOVE Tim. Added.
     /**
     Parse results of selecting or examining a mailbox.
     The format is identical in both cases.

--- a/include/mailio/mime.hpp
+++ b/include/mailio/mime.hpp
@@ -317,19 +317,42 @@ public:
     **/
     std::vector<mime> parts() const;
 
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Setting the message line policy.
+// 
+//     @param line_policy Line policy to set.
+//     **/
+//     void line_policy(codec::line_len_policy_t line_policy);
     /**
-    Setting the message line policy.
+    Setting the message decoding and encoding line policy.
 
-    @param line_policy Line policy to set.
+    @param encoder_line_policy Encoder line policy to set.
+    @param decoder_line_policy Decoder line policy to set.
     **/
-    void line_policy(codec::line_len_policy_t line_policy);
+    void line_policy(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy);
 
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Getting the message line policy.
+// 
+//     @return Line policy.
+//     **/
+//     codec::line_len_policy_t line_policy() const;
     /**
-    Getting the message line policy.
+    Getting the encoder message line policy.
 
-    @return Line policy.
+    @return Encoder line policy.
     **/
     codec::line_len_policy_t line_policy() const;
+
+    // REMOVE Tim. Added. We need a much larger value available for decoding since some emails tested were beyond 2048.
+    /**
+    Getting the message decoder line policy.
+
+    @return Decoder line policy.
+    **/
+    codec::line_len_policy_t decoder_line_policy() const;
 
     /**
     Enabling/disabling the strict mode for the mime part.
@@ -625,11 +648,22 @@ protected:
     **/
     std::string _version;
 
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Line policy to be applied for the mime part.
+//     **/
+//     codec::line_len_policy_t _line_policy;
     /**
-    Line policy to be applied for the mime part.
+    Encoder line policy to be applied for the mime part.
     **/
     codec::line_len_policy_t _line_policy;
-  
+
+// REMOVE Tim. Added. We need a much larger value available for decoding since some emails tested were beyond 2048.
+    /**
+    Decoder line policy to be applied for the mime part.
+    **/
+    codec::line_len_policy_t _decoder_line_policy;
+
     /**
     Strict mode for mime part.
     **/

--- a/include/mailio/mime.hpp
+++ b/include/mailio/mime.hpp
@@ -317,13 +317,6 @@ public:
     **/
     std::vector<mime> parts() const;
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Setting the message line policy.
-// 
-//     @param line_policy Line policy to set.
-//     **/
-//     void line_policy(codec::line_len_policy_t line_policy);
     /**
     Setting the message decoding and encoding line policy.
 
@@ -332,13 +325,6 @@ public:
     **/
     void line_policy(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy);
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Getting the message line policy.
-// 
-//     @return Line policy.
-//     **/
-//     codec::line_len_policy_t line_policy() const;
     /**
     Getting the encoder message line policy.
 
@@ -346,7 +332,6 @@ public:
     **/
     codec::line_len_policy_t line_policy() const;
 
-    // REMOVE Tim. Added. We need a much larger value available for decoding since some emails tested were beyond 2048.
     /**
     Getting the message decoder line policy.
 
@@ -648,17 +633,11 @@ protected:
     **/
     std::string _version;
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Line policy to be applied for the mime part.
-//     **/
-//     codec::line_len_policy_t _line_policy;
     /**
     Encoder line policy to be applied for the mime part.
     **/
     codec::line_len_policy_t _line_policy;
 
-// REMOVE Tim. Added. We need a much larger value available for decoding since some emails tested were beyond 2048.
     /**
     Decoder line policy to be applied for the mime part.
     **/

--- a/include/mailio/q_codec.hpp
+++ b/include/mailio/q_codec.hpp
@@ -37,14 +37,6 @@ public:
     **/
     enum class codec_method_t {BASE64, QUOTED_PRINTABLE};
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Setting the line policy to recommended one.
-// 
-//     @param line_policy  Line policy to apply.
-//     @param codec_method Method for encoding/decoding.
-//     **/
-//     q_codec(codec::line_len_policy_t line_policy, codec_method_t codec_method);
     /**
     Setting the encoder and decoder line policy to recommended one.
 

--- a/include/mailio/q_codec.hpp
+++ b/include/mailio/q_codec.hpp
@@ -37,13 +37,22 @@ public:
     **/
     enum class codec_method_t {BASE64, QUOTED_PRINTABLE};
 
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Setting the line policy to recommended one.
+// 
+//     @param line_policy  Line policy to apply.
+//     @param codec_method Method for encoding/decoding.
+//     **/
+//     q_codec(codec::line_len_policy_t line_policy, codec_method_t codec_method);
     /**
-    Setting the line policy to recommended one.
+    Setting the encoder and decoder line policy to recommended one.
 
-    @param line_policy  Line policy to apply.
+    @param encoder_line_policy  Line policy to apply.
+    @param decoder_line_policy  Line policy to apply.
     @param codec_method Method for encoding/decoding.
     **/
-    q_codec(codec::line_len_policy_t line_policy, codec_method_t codec_method);
+    q_codec(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy, codec_method_t codec_method);
 
     q_codec(const q_codec&) = delete;
 

--- a/include/mailio/quoted_printable.hpp
+++ b/include/mailio/quoted_printable.hpp
@@ -30,13 +30,6 @@ class MAILIO_EXPORT quoted_printable : public codec
 {
 public:
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     /**
-//     Setting the line policy.
-// 
-//     @param line_policy Line length policy to set.
-//     **/
-//     quoted_printable(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
     Setting the encoder and decoder line policy.
 

--- a/include/mailio/quoted_printable.hpp
+++ b/include/mailio/quoted_printable.hpp
@@ -30,12 +30,21 @@ class MAILIO_EXPORT quoted_printable : public codec
 {
 public:
 
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     /**
+//     Setting the line policy.
+// 
+//     @param line_policy Line length policy to set.
+//     **/
+//     quoted_printable(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
     /**
-    Setting the line policy.
+    Setting the encoder and decoder line policy.
 
-    @param line_policy Line length policy to set.
+    @param encoder_line_policy Encoder line length policy to set.
+    @param decoder_line_policy Decoder line length policy to set.
     **/
-    quoted_printable(codec::line_len_policy_t line_policy = codec::line_len_policy_t::NONE);
+    quoted_printable(codec::line_len_policy_t encoder_line_policy = codec::line_len_policy_t::NONE,
+                     codec::line_len_policy_t decoder_line_policy = codec::line_len_policy_t::NONE);
 
     quoted_printable(const quoted_printable&) = delete;
 

--- a/mailio.pc.in
+++ b/mailio.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+sharedlibdir=@libdir@
+includedir=@includedir@
+
+Name: mailio
+Description: Cross-platform MIME library for SMTP, POP3, and IMAP protocols
+Version: @PROJECT_VERSION@
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -lmailio
+Cflags: -I${includedir}
+ 

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -28,7 +28,10 @@ namespace mailio
 const string base64::CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 
-base64::base64(codec::line_len_policy_t line_policy) : codec(line_policy)
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+// base64::base64(codec::line_len_policy_t line_policy) : codec(line_policy)
+base64::base64(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
+  : codec(encoder_line_policy, decoder_line_policy)
 {
 }
 
@@ -119,7 +122,9 @@ string base64::decode(const vector<string>& text) const
 
     for (const auto& line : text)
     {
-        if (line.length() > string::size_type(_line_policy) - 2)
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         if (line.length() > string::size_type(_line_policy) - 2)
+        if (line.length() > string::size_type(_decoder_line_policy) - 2)
             throw codec_error("Bad line policy.");
 
         for (string::size_type ch = 0; ch < line.length() && line[ch] != EQUAL_CHAR; ch++)

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -28,8 +28,6 @@ namespace mailio
 const string base64::CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-// base64::base64(codec::line_len_policy_t line_policy) : codec(line_policy)
 base64::base64(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
   : codec(encoder_line_policy, decoder_line_policy)
 {
@@ -122,8 +120,6 @@ string base64::decode(const vector<string>& text) const
 
     for (const auto& line : text)
     {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         if (line.length() > string::size_type(_line_policy) - 2)
         if (line.length() > string::size_type(_decoder_line_policy) - 2)
             throw codec_error("Bad line policy.");
 

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -24,7 +24,10 @@ namespace mailio
 {
 
 
-binary::binary(codec::line_len_policy_t line_policy) : codec(line_policy)
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+// binary::binary(codec::line_len_policy_t line_policy) : codec(line_policy)
+binary::binary(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
+  : codec(encoder_line_policy, decoder_line_policy)
 {
 }
 

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -24,8 +24,6 @@ namespace mailio
 {
 
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-// binary::binary(codec::line_len_policy_t line_policy) : codec(line_policy)
 binary::binary(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
   : codec(encoder_line_policy, decoder_line_policy)
 {

--- a/src/bit7.cpp
+++ b/src/bit7.cpp
@@ -26,7 +26,10 @@ namespace mailio
 {
 
 
-bit7::bit7(codec::line_len_policy_t line_policy) : codec(line_policy)
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+// bit7::bit7(codec::line_len_policy_t line_policy) : codec(line_policy)
+bit7::bit7(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
+  : codec(encoder_line_policy, decoder_line_policy)
 {
 }
 
@@ -76,7 +79,9 @@ string bit7::decode(const vector<string>& text) const
     string dec_text;
     for (const auto& line : text)
     {
-        if (line.length() > string::size_type(_line_policy))
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         if (line.length() > string::size_type(_line_policy))
+        if (line.length() > string::size_type(_decoder_line_policy))
             throw codec_error("Line policy overflow.");
         
         for (auto ch : line)

--- a/src/bit7.cpp
+++ b/src/bit7.cpp
@@ -26,8 +26,6 @@ namespace mailio
 {
 
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-// bit7::bit7(codec::line_len_policy_t line_policy) : codec(line_policy)
 bit7::bit7(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
   : codec(encoder_line_policy, decoder_line_policy)
 {
@@ -79,8 +77,6 @@ string bit7::decode(const vector<string>& text) const
     string dec_text;
     for (const auto& line : text)
     {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         if (line.length() > string::size_type(_line_policy))
         if (line.length() > string::size_type(_decoder_line_policy))
             throw codec_error("Line policy overflow.");
         

--- a/src/bit8.cpp
+++ b/src/bit8.cpp
@@ -26,8 +26,6 @@ namespace mailio
 {
 
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-// bit8::bit8(codec::line_len_policy_t line_policy) : codec(line_policy)
 bit8::bit8(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
   : codec(encoder_line_policy, decoder_line_policy)
 {
@@ -78,8 +76,6 @@ string bit8::decode(const vector<string>& text) const
     string dec_text;
     for (const auto& line : text)
     {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         if (line.length() > string::size_type(_line_policy))
         if (line.length() > string::size_type(_decoder_line_policy))
             throw codec_error("Line policy overflow.");
         

--- a/src/bit8.cpp
+++ b/src/bit8.cpp
@@ -26,7 +26,10 @@ namespace mailio
 {
 
 
-bit8::bit8(codec::line_len_policy_t line_policy) : codec(line_policy)
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+// bit8::bit8(codec::line_len_policy_t line_policy) : codec(line_policy)
+bit8::bit8(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
+  : codec(encoder_line_policy, decoder_line_policy)
 {
 }
 
@@ -75,7 +78,9 @@ string bit8::decode(const vector<string>& text) const
     string dec_text;
     for (const auto& line : text)
     {
-        if (line.length() > string::size_type(_line_policy))
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         if (line.length() > string::size_type(_line_policy))
+        if (line.length() > string::size_type(_decoder_line_policy))
             throw codec_error("Line policy overflow.");
         
         for (auto ch : line)

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -41,7 +41,10 @@ bool codec::is_utf8_string(const string& txt)
 }
 
 
-codec::codec(codec::line_len_policy_t line_policy) : _line_policy(line_policy), _strict_mode(false)
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+// codec::codec(codec::line_len_policy_t line_policy) : _line_policy(line_policy), _strict_mode(false)
+codec::codec(line_len_policy_t encoder_line_policy, line_len_policy_t decoder_line_policy)
+  : _line_policy(encoder_line_policy), _decoder_line_policy(decoder_line_policy), _strict_mode(false)
 {
 }
 

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -41,8 +41,6 @@ bool codec::is_utf8_string(const string& txt)
 }
 
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-// codec::codec(codec::line_len_policy_t line_policy) : _line_policy(line_policy), _strict_mode(false)
 codec::codec(line_len_policy_t encoder_line_policy, line_len_policy_t decoder_line_policy)
   : _line_policy(encoder_line_policy), _decoder_line_policy(decoder_line_policy), _strict_mode(false)
 {

--- a/src/imap.cpp
+++ b/src/imap.cpp
@@ -339,12 +339,21 @@ void imap::fetch_messages(const std::string& message_nos,
     reset_response_parser();
 }
 
-auto imap::statistics(const string& mailbox) -> mailbox_stat_t
+auto imap::statistics(const string& mailbox, bool unseen, bool uidnext, bool uidvalidity) -> mailbox_stat_t
 {
-    // TODO: It doesn't like search terms it doesn't recognize. "2 BAD ...".
-    //       Some older protocol versions or some servers may not support them.
-    //       Pass a flag indicating whether we want to try "unseen uidnext uidvalidity".
-    _dlg->send(format("STATUS \"" + mailbox + "\" (messages recent unseen uidnext uidvalidity)"));
+    // It doesn't like search terms it doesn't recognize.
+    // Some older protocol versions or some servers may not support them.
+    // So unseen uidnext and uidvalidity are optional.
+    string cmd = "STATUS \"" + mailbox + "\" (messages recent";
+    if(unseen)
+      cmd += " unseen";
+    if(uidnext)
+      cmd += " uidnext";
+    if(uidvalidity)
+      cmd += " uidvalidity";
+    cmd += ")";
+    
+    _dlg->send(format(cmd));
     mailbox_stat_t stat;
     
     bool has_more = true;

--- a/src/imap.cpp
+++ b/src/imap.cpp
@@ -122,21 +122,21 @@ void imap::fetch_message(unsigned long message_no, message& msg, bool header_onl
         
         if (std::get<0>(tag_result_response) == "*")
         {
-// Comment by terminator356. Hm, this response has four parts and the third is FETCH,
-//              but tag_result_response is a tuple and there are only three items,
-//              and all of the libray code wants to parse starting at the third item.
-//             So in this case only, we are including the word FETCH in the parse,
-//              which the code below deems harmless because the FETCH is just a string atom
-//              and the code below just looks for the LIST token.
-//             Nonetheless, the word FETCH will be the first atom returned in the mandatory list.
-//             We could look for the word there. But then for consistency we should change
-//              all the other code to do the same (that is, include the response word).
-
             if (stoul(std::get<1>(tag_result_response)) != message_no)
                 throw imap_error("Fetching message failure.");
 
-            if (!iequals(std::get<2>(tag_result_response), "FETCH"))
-                throw imap_error("Fetching message failure.");
+            // Comment by terminator356. Hm, this response has four parts and the third is FETCH,
+            //              but tag_result_response is a tuple and there are only three items,
+            //              and all of the libray code wants to parse starting at the third item.
+            //             So in this case only, we are including the word FETCH in the parse,
+            //              which the code below deems harmless because the FETCH is just a string atom
+            //              and the code below just looks for the LIST token.
+            //             Nonetheless, the word FETCH will be the first atom returned in the mandatory list.
+            //             We could look for the word there. But then for consistency we should change
+            //              all the other code to do the same (that is, include the response word).
+            //
+            //if (!iequals(std::get<2>(tag_result_response), "FETCH"))
+            //    throw imap_error("Fetching message failure.");
 
             parse_response(std::get<2>(tag_result_response));
             shared_ptr<response_token_t> literal_token = nullptr;
@@ -227,8 +227,8 @@ void imap::fetch_messages(const std::string& message_nos,
         
         if (std::get<0>(tag_result_response) == "*")
         {
-            if (!iequals(std::get<2>(tag_result_response), "FETCH"))
-                throw imap_error("Fetching message failure.");
+            //if (!iequals(std::get<2>(tag_result_response), "FETCH"))
+            //    throw imap_error("Fetching message failure.");
 
             // Grab the message number, if we asked for them instead of uids.
             unsigned long msg_no = 0;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -102,8 +102,6 @@ void message::format(string& message_str, bool dot_escape) const
             ct.charset = _content_type.charset;
             content_part.content_type(ct);
             content_part.content_transfer_encoding(_encoding);
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             content_part.line_policy(_line_policy);
             content_part.line_policy(_line_policy, _decoder_line_policy);
             content_part.strict_mode(_strict_mode);
             content_part.strict_codec_mode(_strict_codec_mode);
@@ -415,8 +413,6 @@ void message::parse_header_line(const string& header_line)
 {
     mime::parse_header_line(header_line);
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     if (header_line.length() > string::size_type(_line_policy))
     if (header_line.length() > string::size_type(_decoder_line_policy))
         throw message_error("Line policy overflow in a header.");
 
@@ -518,8 +514,6 @@ string message::format_address(const string& name, const string& address) const
 
     if (codec::is_utf8_string(name))
     {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         q_codec qc(_line_policy, _header_codec);
         q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
         vector<string> n = qc.encode(name);
         // mail has to be formatted into a single line, otherwise it's an error
@@ -1128,8 +1122,6 @@ string message::format_subject() const
 
     if (codec::is_utf8_string(_subject))
     {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         q_codec qc(_line_policy, _header_codec);
         q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
         vector<string> hdr = qc.encode(_subject);
         subject += hdr.at(0) + codec::CRLF;
@@ -1146,8 +1138,6 @@ string message::format_subject() const
 
 string message::parse_subject(const string& subject) const
 {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     q_codec qc(_line_policy, _header_codec);
     q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
     return qc.check_decode(subject);
 }
@@ -1155,8 +1145,6 @@ string message::parse_subject(const string& subject) const
 
 string message::parse_address_name(const string& address_name) const
 {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     q_codec qc(_line_policy, _header_codec);
     q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
     const string::size_type Q_CODEC_SEPARATORS_NO = 4;
     string::size_type addr_len = address_name.size();

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -102,7 +102,9 @@ void message::format(string& message_str, bool dot_escape) const
             ct.charset = _content_type.charset;
             content_part.content_type(ct);
             content_part.content_transfer_encoding(_encoding);
-            content_part.line_policy(_line_policy);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//             content_part.line_policy(_line_policy);
+            content_part.line_policy(_line_policy, _decoder_line_policy);
             content_part.strict_mode(_strict_mode);
             content_part.strict_codec_mode(_strict_codec_mode);
             content_part.header_codec(_header_codec);
@@ -413,7 +415,9 @@ void message::parse_header_line(const string& header_line)
 {
     mime::parse_header_line(header_line);
 
-    if (header_line.length() > string::size_type(_line_policy))
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     if (header_line.length() > string::size_type(_line_policy))
+    if (header_line.length() > string::size_type(_decoder_line_policy))
         throw message_error("Line policy overflow in a header.");
 
     // TODO: header name and header value already parsed in `mime::parse_header_line`, so this is not the optimal way to do it
@@ -514,7 +518,9 @@ string message::format_address(const string& name, const string& address) const
 
     if (codec::is_utf8_string(name))
     {
-        q_codec qc(_line_policy, _header_codec);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         q_codec qc(_line_policy, _header_codec);
+        q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
         vector<string> n = qc.encode(name);
         // mail has to be formatted into a single line, otherwise it's an error
         if (n.size() > 1)
@@ -1122,7 +1128,9 @@ string message::format_subject() const
 
     if (codec::is_utf8_string(_subject))
     {
-        q_codec qc(_line_policy, _header_codec);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         q_codec qc(_line_policy, _header_codec);
+        q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
         vector<string> hdr = qc.encode(_subject);
         subject += hdr.at(0) + codec::CRLF;
         if (hdr.size() > 1)
@@ -1138,14 +1146,18 @@ string message::format_subject() const
 
 string message::parse_subject(const string& subject) const
 {
-    q_codec qc(_line_policy, _header_codec);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     q_codec qc(_line_policy, _header_codec);
+    q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
     return qc.check_decode(subject);
 }
 
 
 string message::parse_address_name(const string& address_name) const
 {
-    q_codec qc(_line_policy, _header_codec);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     q_codec qc(_line_policy, _header_codec);
+    q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
     const string::size_type Q_CODEC_SEPARATORS_NO = 4;
     string::size_type addr_len = address_name.size();
     if (address_name.size() >= Q_CODEC_SEPARATORS_NO && address_name.at(0) == codec::EQUAL_CHAR && address_name.at(1) == codec::QUESTION_MARK_CHAR &&

--- a/src/mime.cpp
+++ b/src/mime.cpp
@@ -93,8 +93,6 @@ const string mime::CONTENT_ATTR_ALPHABET{"!#$%&*+-.^_`|~"};
 const string mime::CONTENT_HEADER_VALUE_ALPHABET{"!#$%&*+-./^_`|~"};
 
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//mime::mime() : _version("1.0"), _line_policy(codec::line_len_policy_t::RECOMMENDED), _strict_mode(false), _strict_codec_mode(false),
 mime::mime() : _version("1.0"), _line_policy(codec::line_len_policy_t::RECOMMENDED),
   _decoder_line_policy(codec::line_len_policy_t::RECOMMENDED), _strict_mode(false), _strict_codec_mode(false),
     _header_codec(header_codec_t::QUOTED_PRINTABLE), _content_type(media_type_t::NONE, ""), _encoding(content_transfer_encoding_t::NONE),
@@ -183,8 +181,6 @@ mime& mime::parse_by_line(const string& line, bool dot_escape)
                     if (!_parts.empty())
                         _parts.back().parse_by_line("\r\n");
                     mime m;
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//                     m.line_policy(_line_policy);
                     m.line_policy(_line_policy, _decoder_line_policy);
                     m.strict_codec_mode(_strict_codec_mode);
                     _parts.push_back(m);
@@ -317,11 +313,6 @@ vector<mime> mime::parts() const
 }
 
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-// void mime::line_policy(codec::line_len_policy_t line_policy)
-// {
-//     _line_policy = line_policy;
-// }
 void mime::line_policy(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
 {
     _line_policy = encoder_line_policy;
@@ -335,7 +326,6 @@ codec::line_len_policy_t mime::line_policy() const
 }
 
 
-// REMOVE Tim. Added. We need a much larger value available for decoding since some emails tested were beyond 2048.
 codec::line_len_policy_t mime::decoder_line_policy() const
 {
     return _decoder_line_policy;
@@ -394,8 +384,6 @@ string mime::format_header() const
         if (!_name.empty())
         {
             string mn = format_mime_name(_name);
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             if (header.size() + SEMICOLON.size() + sizeof("name=\"") + mn.size() + sizeof("\"") < string::size_type(codec::line_len_policy_t::RECOMMENDED) - 2)
             if (header.size() + SEMICOLON.size() + sizeof("name=\"") + mn.size() + sizeof("\"") < string::size_type(_line_policy) - 2)
                 header += SEMICOLON + "name=\"" + mn + "\"";
             else
@@ -439,8 +427,6 @@ string mime::format_header() const
             string name = format_mime_name(_name);
             header += CONTENT_DISPOSITION_HEADER + COLON + CONTENT_DISPOSITION_ATTACHMENT + "; ";
             if (CONTENT_DISPOSITION_HEADER.size() + COLON.size() + CONTENT_DISPOSITION_ATTACHMENT.size() + sizeof("filename=\"") + name.size() +
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//                 sizeof("\"\r\n") < string::size_type(codec::line_len_policy_t::RECOMMENDED) - 2)
                 sizeof("\"\r\n") < string::size_type(_line_policy) - 2)
             {
                 header += "filename=\"" + name + "\"\r\n";
@@ -455,8 +441,6 @@ string mime::format_header() const
             string name = format_mime_name(_name);
             header += CONTENT_DISPOSITION_HEADER + COLON + CONTENT_DISPOSITION_INLINE + "; ";
             if (CONTENT_DISPOSITION_HEADER.size() + COLON.size() + CONTENT_DISPOSITION_INLINE.size() + sizeof("filename=\"") + name.size() +
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//                 sizeof("\"\r\n") < string::size_type(codec::line_len_policy_t::RECOMMENDED) - 2)
                 sizeof("\"\r\n") < string::size_type(_line_policy) - 2)
             {
                 header += "filename=\"" + name + "\"\r\n";
@@ -481,8 +465,6 @@ string mime::format_content(bool dot_escape) const
     {
         case content_transfer_encoding_t::BASE_64:
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             base64 b(_line_policy);
             base64 b(_line_policy, _decoder_line_policy);
             b.strict_mode(_strict_codec_mode);
             content_lines = b.encode(_content);
@@ -491,8 +473,6 @@ string mime::format_content(bool dot_escape) const
 
         case content_transfer_encoding_t::QUOTED_PRINTABLE:
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             quoted_printable qp(_line_policy);
             quoted_printable qp(_line_policy, _decoder_line_policy);
             qp.strict_mode(_strict_codec_mode);
             content_lines = qp.encode(_content);
@@ -502,8 +482,6 @@ string mime::format_content(bool dot_escape) const
         // TODO: check how to handle 8bit chars, see [rfc 2045, section 2.8]
         case content_transfer_encoding_t::BIT_8:
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             bit8 b8(_line_policy);
             bit8 b8(_line_policy, _decoder_line_policy);
             b8.strict_mode(_strict_codec_mode);
             content_lines = b8.encode(_content);
@@ -514,8 +492,6 @@ string mime::format_content(bool dot_escape) const
         case content_transfer_encoding_t::BIT_7:
         case content_transfer_encoding_t::NONE:
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             bit7 b7(_line_policy);
             bit7 b7(_line_policy, _decoder_line_policy);
             b7.strict_mode(_strict_codec_mode);
             content_lines = b7.encode(_content);
@@ -525,8 +501,6 @@ string mime::format_content(bool dot_escape) const
         case content_transfer_encoding_t::BINARY:
         {
             // TODO: probably bug when `\0` is part of the content
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             binary b(_line_policy);
             binary b(_line_policy, _decoder_line_policy);
             b.strict_mode(_strict_codec_mode);
             content_lines = b.encode(_content);
@@ -552,8 +526,6 @@ string mime::format_mime_name(const string& name) const
     if (codec::is_utf8_string(name))
     {
         // if the attachment name exceeds mandatory length, the rest is discarded
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         q_codec qc(codec::line_len_policy_t::MANDATORY, _header_codec);
         q_codec qc(codec::line_len_policy_t::MANDATORY, _decoder_line_policy, _header_codec);
         vector<string> hdr = qc.encode(name);
         return hdr.at(0);
@@ -593,8 +565,6 @@ void mime::parse_content()
     {
         case content_transfer_encoding_t::BASE_64:
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             base64 b64(_line_policy);
             base64 b64(_line_policy, _decoder_line_policy);
             b64.strict_mode(_strict_codec_mode);
             _content = b64.decode(_parsed_body);
@@ -603,8 +573,6 @@ void mime::parse_content()
 
         case content_transfer_encoding_t::QUOTED_PRINTABLE:
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             quoted_printable qp(_line_policy);
             quoted_printable qp(_line_policy, _decoder_line_policy);
             qp.strict_mode(_strict_codec_mode);
             _content = qp.decode(_parsed_body);
@@ -613,8 +581,6 @@ void mime::parse_content()
 
         case content_transfer_encoding_t::BIT_8:
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             bit8 b8(_line_policy);
             bit8 b8(_line_policy, _decoder_line_policy);
             b8.strict_mode(_strict_codec_mode);
             _content = b8.decode(_parsed_body);
@@ -624,8 +590,6 @@ void mime::parse_content()
         case content_transfer_encoding_t::BIT_7:
         case content_transfer_encoding_t::NONE:
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             bit7 b7(_line_policy);
             bit7 b7(_line_policy, _decoder_line_policy);
             b7.strict_mode(_strict_codec_mode);
             _content = b7.decode(_parsed_body);
@@ -634,8 +598,6 @@ void mime::parse_content()
 
         case content_transfer_encoding_t::BINARY:
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             binary b(_line_policy);
             binary b(_line_policy, _decoder_line_policy);
             b.strict_mode(_strict_codec_mode);
             _content = b.decode(_parsed_body);
@@ -681,8 +643,6 @@ void mime::parse_header_line(const string& header_line)
         // name is set if not already set by content disposition
         if (name_it != attributes.end() && _name.empty())
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             q_codec qc(codec::line_len_policy_t::RECOMMENDED, _header_codec);
             q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
             _name = qc.check_decode(name_it->second);
         }
@@ -700,8 +660,6 @@ void mime::parse_header_line(const string& header_line)
         attributes_t::iterator filename_it = attributes.find("filename");
         if (filename_it != attributes.end())
         {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//             q_codec qc(codec::line_len_policy_t::RECOMMENDED, _header_codec);
             q_codec qc(_line_policy, _decoder_line_policy, _header_codec);
             _name = qc.check_decode(filename_it->second);
         }

--- a/src/q_codec.cpp
+++ b/src/q_codec.cpp
@@ -31,8 +31,11 @@ const string q_codec::BASE64_CODEC_STR = "B";
 const string q_codec::QP_CODEC_STR = "Q";
 
 
-q_codec::q_codec(codec::line_len_policy_t line_policy, codec_method_t codec_method) :
-    codec(line_policy), _codec_method(codec_method)
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+// q_codec::q_codec(codec::line_len_policy_t line_policy, codec_method_t codec_method) :
+//     codec(line_policy), _codec_method(codec_method)
+q_codec::q_codec(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy, codec_method_t codec_method) :
+    codec(encoder_line_policy, decoder_line_policy), _codec_method(codec_method)
 {
 }
 
@@ -45,13 +48,17 @@ vector<string> q_codec::encode(const string& text) const
     if (_codec_method == codec_method_t::BASE64)
     {
         codec_flag = BASE64_CODEC_STR;
-        base64 b64(_line_policy);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         base64 b64(_line_policy);
+        base64 b64(_line_policy, _decoder_line_policy);
         text_c = b64.encode(text, Q_FLAGS_LEN);
     }
     else
     {
         codec_flag = QP_CODEC_STR;
-        quoted_printable qp(_line_policy);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         quoted_printable qp(_line_policy);
+        quoted_printable qp(_line_policy, _decoder_line_policy);
         qp.q_codec_mode(true);
         text_c = qp.encode(text, Q_FLAGS_LEN);
     }
@@ -84,7 +91,9 @@ string q_codec::decode(const string& text) const
     string dec_text;
     if (iequals(method, BASE64_CODEC_STR))
     {
-        base64 b64(_line_policy);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//         base64 b64(_line_policy);
+        base64 b64(_line_policy, _decoder_line_policy);
         dec_text = b64.decode(text_c);
     }
     else if (iequals(method, QP_CODEC_STR))
@@ -135,7 +144,9 @@ string q_codec::check_decode(const string& text) const
 
 string q_codec::decode_qp(const string& text) const
 {
-    quoted_printable qp(_line_policy);
+// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
+//     quoted_printable qp(_line_policy);
+    quoted_printable qp(_line_policy, _decoder_line_policy);
     qp.q_codec_mode(true);
     vector<string> lines;
     lines.push_back(text);

--- a/src/q_codec.cpp
+++ b/src/q_codec.cpp
@@ -31,9 +31,6 @@ const string q_codec::BASE64_CODEC_STR = "B";
 const string q_codec::QP_CODEC_STR = "Q";
 
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-// q_codec::q_codec(codec::line_len_policy_t line_policy, codec_method_t codec_method) :
-//     codec(line_policy), _codec_method(codec_method)
 q_codec::q_codec(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy, codec_method_t codec_method) :
     codec(encoder_line_policy, decoder_line_policy), _codec_method(codec_method)
 {
@@ -48,16 +45,12 @@ vector<string> q_codec::encode(const string& text) const
     if (_codec_method == codec_method_t::BASE64)
     {
         codec_flag = BASE64_CODEC_STR;
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         base64 b64(_line_policy);
         base64 b64(_line_policy, _decoder_line_policy);
         text_c = b64.encode(text, Q_FLAGS_LEN);
     }
     else
     {
         codec_flag = QP_CODEC_STR;
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         quoted_printable qp(_line_policy);
         quoted_printable qp(_line_policy, _decoder_line_policy);
         qp.q_codec_mode(true);
         text_c = qp.encode(text, Q_FLAGS_LEN);
@@ -91,8 +84,6 @@ string q_codec::decode(const string& text) const
     string dec_text;
     if (iequals(method, BASE64_CODEC_STR))
     {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         base64 b64(_line_policy);
         base64 b64(_line_policy, _decoder_line_policy);
         dec_text = b64.decode(text_c);
     }
@@ -144,8 +135,6 @@ string q_codec::check_decode(const string& text) const
 
 string q_codec::decode_qp(const string& text) const
 {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//     quoted_printable qp(_line_policy);
     quoted_printable qp(_line_policy, _decoder_line_policy);
     qp.q_codec_mode(true);
     vector<string> lines;

--- a/src/quoted_printable.cpp
+++ b/src/quoted_printable.cpp
@@ -28,8 +28,6 @@ namespace mailio
 {
 
 
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-// quoted_printable::quoted_printable(codec::line_len_policy_t line_policy) : codec(line_policy), _q_codec_mode(false)
 quoted_printable::quoted_printable(codec::line_len_policy_t encoder_line_policy, codec::line_len_policy_t decoder_line_policy)
   : codec(encoder_line_policy, decoder_line_policy), _q_codec_mode(false)
 {
@@ -206,8 +204,6 @@ string quoted_printable::decode(const vector<string>& text) const
     string dec_text;
     for (const auto& line : text)
     {
-// REMOVE Tim. Changed. We need a much larger value available for decoding since some emails tested were beyond 2048.
-//         if (line.length() > string::size_type(_line_policy) - 2)
         if (line.length() > string::size_type(_decoder_line_policy) - 2)
             throw codec_error("Bad line policy.");
 
@@ -224,10 +220,8 @@ string quoted_printable::decode(const vector<string>& text) const
                     soft_break = true;
                     continue;
                 }
-                
-// REMOVE Tim. Changed. Exception on lower case letters.
-//                 char next_char = *(ch + 1);
-//                 char next_next_char = *(ch + 2);
+
+                // Avoid exception: Convert to uppercase.
                 char next_char = toupper(*(ch + 1));
                 char next_next_char = toupper(*(ch + 2));
                 if (!is_allowed(next_char) || !is_allowed(next_next_char))


### PR DESCRIPTION
Hi. Here is my full, cleaned up working version of the library.
It is **not** incremental to my last pull request, rather it is the complete thing.
I added the final piece in the imap suite of methods:
The fetch_messages() method. This really makes it shine.
In my test app, by batching about 100 messages at a time I saw a dramatic speed boost
 over the 'one-at-a-time' fetch_message() method.
(An RFC recommends batching rather than getting all of them.)

Basic steps to an imap caching mail retrieval system using this mailio fork:
1) Connect with an instance of mailio::imaps, and authenticate() as usual.
2) Use list_folders() to build your disk folder tree.
3) Use examine_mailbox() to 'examine' a folder and return mailbox stats.
4) Use stat.uidvalidity to determine if server supports uids. Call it say, "bool has_uids".
    Keep that uidvalidity number handy, you'll need it.
5) Call search_messages("ALL", list, has_uids) to fill a std::list (unsigned long)
     with a list of all the message uids. This very fast.
    These message uids must be combined with the uidvalidity number to form a
     64-bit value which truly uniquely identifies each messge.
6) Using that 64-bit "uid", plan to name each one of your cache files "(full_uid).mailio" for example.
    Plan to store a few useful pieces of information in each cache file such as sender, subject,
    and how many attachments etc. (Requires full headers in the fetch_messages() call.)
7) Now, you can easily check for missing / removed messages in your disk cache directory
     by comparing against those uids. If for example file "456745354.mailio" exists
     but 456745354 is not in the list returned by search_messages (when those
     numbers are combined with the uidvalidity) then you can safely delete the file.
8) Now, similarly you can check for new messages by seeing which numbers
     are in the list but not stored as a cache file. Create new files as "(full_uid).mailio" for example.
    Use fetch_messages() to now retrieve the necessary new messages.
    With fetch_messages() you must compose and pass your own numbers list string like this:
     "1:4,5,6,7,8:10". In this case they will be message uids (without the uidvalidity part.)
9) Now that the full set of cache files has been built, your app now can fill visual elements, lists etc.
     with a scan of all those cache files. When a user clicks on such a list item,
     you can display the message in a message pane.

Here is a snapshot of my test app:
![Screenshot_20190327_002503_2](https://user-images.githubusercontent.com/5422362/55052265-ac3e6a00-502e-11e9-90ec-e9a7c54761a5.jpeg)
