### PR TITLE
Added support for POP3 UIDL command

### DIFF
--- a/include/mailio/pop3.hpp
+++ b/include/mailio/pop3.hpp
@@ -48,6 +48,11 @@ public:
     **/
     typedef std::map<unsigned, unsigned long> message_list_t;
 
+	/**
+	Message order numbers and their corresponding unique IDs (a UIDL response from server).
+	**/
+	typedef std::map<unsigned, std::string> uidl_list_t;
+
     /**
     Mailbox statistics structure.
     **/
@@ -119,6 +124,18 @@ public:
     @todo             This method is perhaps useless and should be removed.
     **/
     message_list_t list(unsigned message_no = 0);
+
+	/**
+	Getting the unique ID of a message or all messages in a mailbox (UIDL command; might not be supported by server).
+
+	@param message_no Number of the message to get ID for. If zero, then all messages are listed.
+	@return           Uidl list.
+	@throw pop3_error Listing message failure.
+	@throw pop3_error Listing all messages failure.
+	@throw pop3_error Parser failure.
+	@throw *          `parse_status(const string&)`, `dialog::send(const string&)`, `dialog::receive()`.
+	**/
+	uidl_list_t uidl(unsigned message_no = 0);
 
     /**
     Fetching the mailbox statistics.


### PR DESCRIPTION
Added support for optional POP3 UIDL command which allows to fetch unique message IDs other than those offered by `Message-ID` header.

Since one can't always rely on `Message-ID` headers which are often ill-formed or even missing, it would be good to have some other IDs.