### PR TITLE
provide the smtp servers text on accepting mail

### DIFF
--- a/include/mailio/smtp.hpp
+++ b/include/mailio/smtp.hpp
@@ -83,6 +83,7 @@ public:
     Submitting a message.
 
     @param msg        Mail message to send.
+    @return           The SMTP server's reply on accepting the message.
     @throw smtp_error Mail sender rejection.
     @throw smtp_error Mail recipient rejection.
     @throw smtp_error Mail group recipient rejection.
@@ -93,7 +94,7 @@ public:
     @throw smtp_error Mail message rejection.
     @throw *          `parse_line(const string&)`, `dialog::send(const string&)`, `dialog::receive()`.
     **/
-    void submit(const message& msg);
+    std::string submit(const message& msg);
 
     /**
     Setting the source hostname.

--- a/src/smtp.cpp
+++ b/src/smtp.cpp
@@ -77,7 +77,7 @@ string smtp::authenticate(const string& username, const string& password, auth_m
 }
 
 
-void smtp::submit(const message& msg)
+string smtp::submit(const message& msg)
 {
     if (!msg.sender().address.empty())
         _dlg->send("MAIL FROM: " + message::ADDRESS_BEGIN_STR + msg.sender().address + message::ADDRESS_END_STR);
@@ -155,6 +155,7 @@ void smtp::submit(const message& msg)
     tokens = parse_line(line);
     if (!positive_completion(std::get<0>(tokens)))
         throw smtp_error("Mail message rejection.");
+    return std::get<2>(tokens);
 }
 
 


### PR DESCRIPTION
When an SMTP server accapts a mail message it responds with a positive
completion status (2xy code) and some kind of informative text, usually
containing a queued ID, e.g. "Ok: queued as 9F04854013C".

One might want to keep this text or save it to a log file as a proof
that the mail message has been sent correctly.

In order to do so, this patch adds a return string to the smpt::submit()
method, which returns exactly this text.