### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ From the terminal go into the directory where the library is downloaded to, and 
 mkdir build
 cd ./build
 cmake ..
-make install
+sudo make install
 ```
 
 


### PR DESCRIPTION
`make install` needs `sudo` since it copies files into /usr/local, which is a root directory