### PR TITLE
mingw gcc missing ws2_32 library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,10 @@ if(OPENSSL_FOUND)
     target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
 endif()
 
+if(WIN32)
+    target_link_libraries(${PROJECT_NAME} -lws2_32 )
+endif(WIN32)
+
 install(DIRECTORY include/mailio DESTINATION ${INCLUDE_INSTALL_DIR})
 
 install(TARGETS ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,9 +164,9 @@ if(OPENSSL_FOUND)
     target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
 endif()
 
-if(WIN32)
+if(MINGW)
     target_link_libraries(${PROJECT_NAME} -lws2_32 )
-endif(WIN32)
+endif(MINGW)
 
 install(DIRECTORY include/mailio DESTINATION ${INCLUDE_INSTALL_DIR})
 


### PR DESCRIPTION
- Adding lib ws2_32 to fix compilation error on mingw gcc
	modified:   CMakeLists.txt