### PR TITLE
Added tests for RFC 2047

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ endif(NOT SHARE_INSTALL_DIR)
 option(MAILIO_BUILD_DOCUMENTATION "Turn on to build doxygen based documentation." ON)
 option(MAILIO_BUILD_EXAMPLES "Turn on to build examples." ON)
 option(MAILIO_BUILD_SHARED_LIBRARY "Turn on to build the shared library." OFF)
+option(MAILIO_MAKE_TESTS "Make and run tests." ON)
 
 # add a dependent option to build latex documentation or not.
 include(CMakeDependentOption)
@@ -196,3 +197,9 @@ if(${MAILIO_BUILD_EXAMPLES})
     file(GLOB PNGS "${PROJECT_SOURCE_DIR}/examples/*.png")
     install(FILES ${PNGS} DESTINATION "${SHARE_INSTALL_DIR}/${PROJECT_NAME}/examples/")
 endif(${MAILIO_BUILD_EXAMPLES})
+
+# optionally make tests
+if(${MAILIO_MAKE_TESTS})
+    add_subdirectory(tests)
+endif(${MAILIO_MAKE_TESTS})
+

--- a/include/mailio/codec.hpp
+++ b/include/mailio/codec.hpp
@@ -439,6 +439,16 @@ public:
     **/
     static const std::string CHARSET_UTF8;
 
+		/**
+		Start of encoding.
+		**/
+		static const std::string ENCODING_START;
+
+		/**
+		End of encoding.
+		**/
+		static const std::string ENCODING_END;
+
     /**
     Line length policy.
 

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -34,8 +34,10 @@ const string codec::SEMICOLON_STR(1, codec::SEMICOLON_CHAR);
 const string codec::QUOTE_STR(1, codec::QUOTE_CHAR);
 const string codec::LESS_THAN_STR(1, codec::LESS_THAN_CHAR);
 const string codec::GREATER_THAN_STR(1, codec::GREATER_THAN_CHAR);
-const string codec::CHARSET_ASCII("ASCII");
-const string codec::CHARSET_UTF8("UTF-8");
+const string codec::CHARSET_ASCII{"ASCII"};
+const string codec::CHARSET_UTF8{"UTF-8"};
+const string codec::ENCODING_START{"=?"};
+const string codec::ENCODING_END{"?="};
 
 
 int codec::hex_digit_to_int(char digit)

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -1513,19 +1513,50 @@ string_t message::parse_address_name(const string& address_name) const
     q_codec qc(_line_policy, _decoder_line_policy);
     const string::size_type Q_CODEC_SEPARATORS_NO = 4;
     string::size_type addr_len = address_name.size();
-    bool is_q_encoded = address_name.size() >= Q_CODEC_SEPARATORS_NO && address_name.at(0) == codec::EQUAL_CHAR &&
-        address_name.at(1) == codec::QUESTION_MARK_CHAR && address_name.at(addr_len - 1) == codec::EQUAL_CHAR &&
-        address_name.at(addr_len - 2) == codec::QUESTION_MARK_CHAR;
-    if (is_q_encoded)
-    {
-        auto an = qc.decode(address_name.substr(1, addr_len - 3));
-        return string_t(get<0>(an), get<1>(an));
-    }
+		size_t start = 0, pos = 0;
+		string decoded;
+		string encoding;
+		while (start < addr_len) {
+			size_t pos = address_name.find(codec::ENCODING_START, start);
+			if (pos != string::npos) {
+				if (pos > start) {
+					decoded += address_name.substr(start, pos - start);
+				}	
+				size_t end = address_name.find(codec::ENCODING_END, pos);
+				if (end != string::npos) {
+        	auto an = qc.decode(address_name.substr(pos, end - pos));
+					if (!encoding.empty() && (encoding != std::get<1>(an))) {
+							stringstream ss;
+            	ss << "Encoding does not match `" << address_name[start] << "` in \"" << address_name << "\" (pos=" << start << ").";
+							string err = ss.str();	
+            	throw message_error(err);
+					} else {
+						encoding = std::get<1>(an);
+					}
+					decoded += std::get<0>(an);
+					start = end + codec::ENCODING_END.length();
+					while (start < addr_len && (address_name[start] == ' ' || address_name[start] == '\r' || address_name[start] == '\n')) {
+						start++;
+					}
+					continue;
+				} else {
+					//do nothing, fall through
+				}
+			} 
+			decoded += address_name.substr(start);
+			if (pos == string::npos) {
+				break;
+			}
+		}
+			if (encoding.empty()) {
+				 	if (codec::is_utf8_string(decoded))
+     				return string_t(decoded, codec::CHARSET_UTF8);
+ 					else
+        		return string_t(decoded, codec::CHARSET_ASCII);
+			} else {
+					return string_t(decoded, encoding);
+			}
 
-    if (codec::is_utf8_string(address_name))
-        return string_t(address_name, codec::CHARSET_UTF8);
-    else
-        return string_t(address_name, codec::CHARSET_ASCII);
 }
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.23)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+set(PROJECT_NAME test_mailio)
+find_package(Boost REQUIRED COMPONENTS system date_time regex)
+find_package(OpenSSL)
+
+enable_testing()
+
+add_executable(
+  ${PROJECT_NAME}
+  test_message.cpp
+  ${project_sources}
+)
+target_link_libraries(
+  ${PROJECT_NAME}
+  gtest_main
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include/ PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../ PUBLIC ${Boost_INCLUDE_DIRS} PUBLIC ${OPENSSL_INCLUDE_DIR})
+message("MESSAGE DONE ${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR}")
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES})
+
+
+include(GoogleTest)
+gtest_discover_tests(${PROJECT_NAME})
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.16.3)
 
 include(FetchContent)
 FetchContent_Declare(
@@ -24,7 +24,6 @@ target_link_libraries(
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include/ PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../ PUBLIC ${Boost_INCLUDE_DIRS} PUBLIC ${OPENSSL_INCLUDE_DIR})
-message("MESSAGE DONE ${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES})
 
 

--- a/tests/test_message.cpp
+++ b/tests/test_message.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+#include <string>
+#include <mailio/message.hpp>
+
+using namespace mailio;
+using namespace std;
+
+class tmessage : public message {
+	public:
+		string_t parse_address_name(const string& address_name) const {
+			return message::parse_address_name(address_name);
+    }
+};
+
+/*Orinal code passes it*/
+TEST(SimpleTest, BasicAssertions) {
+	string testStr = "John Smith";
+	string_t ret;
+
+  tmessage msg;
+	msg.line_policy(codec::line_len_policy_t::NONE, codec::line_len_policy_t::NONE);
+  try {
+		ret = msg.parse_address_name(testStr);		
+  } catch (codec_error &err) {
+    ret.buffer = err.what();	
+  }
+  // Expect two strings not to be equal.
+  EXPECT_EQ(ret, "John Smith");
+}
+
+/*Orinal code passes it*/
+TEST(NonRepeatTest, BasicAssertions) {
+	string testStr = "=?UTF-8?B?Vm9sdGEg0YfQtdGA0LXQtyDQpNC+0YDRg9C8INCT0L7QstC+0YDQuNC8INC/?=";
+	string_t ret;
+
+  tmessage msg;
+	msg.line_policy(codec::line_len_policy_t::NONE, codec::line_len_policy_t::NONE);
+  try {
+		ret = msg.parse_address_name(testStr);		
+  } catch (codec_error &err) {
+    ret.buffer = err.what();	
+  }
+  // Expect two strings not to be equal.
+  EXPECT_EQ(ret, "Volta через Форум Говорим п");
+}
+
+/*Orinal code does not pass it*/
+TEST(RepeatTest, BasicAssertions) {
+	string testStr = "=?UTF-8?B?Vm9sdGEg0YfQtdGA0LXQtyDQpNC+0YDRg9C8INCT0L7QstC+0YDQuNC8INC/?= =?UTF-8?B?0YDQviDQkNC80LXRgNC40LrRgw==?=";
+	string_t ret;
+
+  tmessage msg;
+	msg.line_policy(codec::line_len_policy_t::NONE, codec::line_len_policy_t::NONE);
+  try {
+		ret = msg.parse_address_name(testStr);		
+  } catch (codec_error &err) {
+    ret.buffer = err.what();	
+  }
+  // Expect two strings not to be equal.
+  EXPECT_EQ(ret, "Volta через Форум Говорим про Америку");
+}
+


### PR DESCRIPTION
Per RFC 2047, encoded words are limited by 75 characters.
Everything longer than that is to be broken in encoded words, separated by CRLF SPACE.
These tests exhibit the problem.
I have a proposed fix and will follow up with it.
