### PR TITLE
Test for name of a multipart part set in Content-Disposition header

### DIFF
--- a/include/mailio/mime.hpp
+++ b/include/mailio/mime.hpp
@@ -265,11 +265,25 @@ public:
     void name(const std::string& mime_name);
 
     /**
+    Setting the HTTP mime name.
+
+    @param mime_name HTTP Mime name to set.
+    **/
+    void http_name(const std::string& http_name);
+
+    /**
     Getting the mime name.
 
     @return Mime name.
     **/
     std::string name() const;
+
+    /**
+    Getting the HTTP MIME name.
+
+    @return HTTP MIME name.
+    **/
+    std::string http_name() const;
 
     /**
     Setting the content transfer encoding.
@@ -778,6 +792,11 @@ protected:
     @todo Should it contain filename of the attachment?
     **/
     std::string name_;
+
+    /**
+    Content-Disposition HTTP name of mime.
+    **/
+    std::string http_name_;
 
     /**
     Content transfer encoding of the mime part.

--- a/src/mime.cpp
+++ b/src/mime.cpp
@@ -728,6 +728,13 @@ void mime::parse_header_line(const string& header_line)
             q_codec qc(line_policy_, decoder_line_policy_);
             name_ = get<0>(qc.check_decode(filename_it->second));
         }
+        // HTTP name
+        attributes_t::iterator httpname_it = attributes.find(ATTRIBUTE_NAME);
+        if (httpname_it != attributes.end())
+        {
+            q_codec qc(line_policy_, decoder_line_policy_);
+            http_name_ = get<0>(qc.check_decode(httpname_it->second));
+        }
     }
 }
 

--- a/src/mime.cpp
+++ b/src/mime.cpp
@@ -281,6 +281,18 @@ string mime::name() const
 }
 
 
+void mime::http_name(const string& http_name)
+{
+    http_name_ = http_name;
+}
+
+
+string mime::http_name() const
+{
+    return http_name_;
+}
+
+
 void mime::content_transfer_encoding(content_transfer_encoding_t encoding)
 {
     encoding_ = encoding;

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -4169,7 +4169,7 @@ BOOST_AUTO_TEST_CASE(parse_multipart_content)
     BOOST_CHECK(msg.parts().at(0).content_type().type == mime::media_type_t::TEXT && msg.parts().at(0).content_type().subtype == "html" &&
         msg.parts().at(0).content_transfer_encoding() == mime::content_transfer_encoding_t::BASE_64 &&
         msg.parts().at(0).content_type().charset == "utf-8" &&
-        msg.parts().at(0).name() == "name" &&
+        msg.parts().at(0).http_name() == "name" &&
         msg.parts().at(0).content() == "<html><head></head><body><h1>Ćao, Svete!</h1></body></html>");
     BOOST_CHECK(msg.parts().at(1).content_type().type == mime::media_type_t::TEXT && msg.parts().at(1).content_type().subtype == "plain" &&
         msg.parts().at(1).content_transfer_encoding() == mime::content_transfer_encoding_t::QUOTED_PRINTABLE &&

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -4148,6 +4148,7 @@ BOOST_AUTO_TEST_CASE(parse_multipart_content)
         "--my_bound\r\n"
         "Content-Type: text/html; charset=utf-8\r\n"
         "Content-Transfer-Encoding: Base64\r\n"
+        "Content-Disposition: form-data; name=\"name\"\r\n"
         "\r\n"
         "PGh0bWw+PGhlYWQ+PC9oZWFkPjxib2R5PjxoMT7EhmFvLCBTdmV0ZSE8L2gxPjwvYm9keT48L2h0bWw+\r\n"
         "\r\n"
@@ -4168,6 +4169,7 @@ BOOST_AUTO_TEST_CASE(parse_multipart_content)
     BOOST_CHECK(msg.parts().at(0).content_type().type == mime::media_type_t::TEXT && msg.parts().at(0).content_type().subtype == "html" &&
         msg.parts().at(0).content_transfer_encoding() == mime::content_transfer_encoding_t::BASE_64 &&
         msg.parts().at(0).content_type().charset == "utf-8" &&
+        msg.parts().at(0).name() == "name" &&
         msg.parts().at(0).content() == "<html><head></head><body><h1>Ćao, Svete!</h1></body></html>");
     BOOST_CHECK(msg.parts().at(1).content_type().type == mime::media_type_t::TEXT && msg.parts().at(1).content_type().subtype == "plain" &&
         msg.parts().at(1).content_transfer_encoding() == mime::content_transfer_encoding_t::QUOTED_PRINTABLE &&


### PR DESCRIPTION
I've coded down what I would like to see in my web attachments handling with mailio, regarding "name" attribute, currently mime::name_ is set to the value of "filename" Content-Disposition attr