### PR TITLE
Explicitly specifying only to use ISO standard C++ in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required (VERSION 3.16.3)
 project(mailio VERSION 0.24.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(NOT DEFINED LIB_SUFFIX)
   set(LIB_SUFFIX "" CACHE STRING "Suffix for installed library path. Ex. 64 for lib64")


### PR DESCRIPTION
Related #142

I am strongly convinced that compiler specific extensions should not be used for projects that support various platforms including especially Windows.
