### PR TITLE
cmake: copy version.hpp and mailio.pc to CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,11 +138,11 @@ else(IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}")
   set(includedir "\${prefix}/${INCLUDE_INSTALL_DIR}/${PROJECT_NAME}")
 endif(IS_ABSOLUTE "${INCLUDE_INSTALL_DIR}")
 
-configure_file(mailio.pc.in ${CMAKE_BINARY_DIR}/mailio.pc IMMEDIATE @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/mailio.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+configure_file(mailio.pc.in ${CMAKE_CURRENT_BINARY_DIR}/mailio.pc IMMEDIATE @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mailio.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
 
-configure_file(${PROJECT_SOURCE_DIR}/include/version.hpp.in version.hpp)
-install(FILES ${CMAKE_BINARY_DIR}/version.hpp DESTINATION ${INCLUDE_INSTALL_DIR}/${PROJECT_NAME})
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/version.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/version.hpp)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/version.hpp DESTINATION ${INCLUDE_INSTALL_DIR}/${PROJECT_NAME})
 
 # generate the export header for exporting symbols
 # this is needed to generate a shared library.


### PR DESCRIPTION
Still have problem #126 when use cmake fetchContent to import mailio, after copy to CMAKE_CURRENT_BINARY_DIR, they will in build dir. No different when build mailio project

before:
<img width="624" alt="3" src="https://github.com/karastojko/mailio/assets/25531652/9333a1cb-367a-4602-9e32-6d6801c327ea">

<img width="387" alt="2" src="https://github.com/karastojko/mailio/assets/25531652/db350c28-83c9-4704-9e55-55404b8f0948">

after:
<img width="390" alt="1" src="https://github.com/karastojko/mailio/assets/25531652/d0fee5cf-d90d-4625-be71-f57f868b9bf2">
