### PR TITLE
imap flags

### DIFF
--- a/include/mailio/imap.hpp
+++ b/include/mailio/imap.hpp
@@ -312,6 +312,39 @@ public:
         bool header_only = false, codec::line_len_policy_t line_policy = codec::line_len_policy_t::RECOMMENDED);
 
     /**
+     Fetches the flags of a message in the specified mailbox.
+    
+     @param message_no the number of the message
+     @param flags a vector to store the found flags
+     @param is_uids whether the message number is a UID
+     @throws imap_error if the fetch operation fails
+    */
+    void fetch_flags(unsigned long message_no, std::vector<std::string>& flags, bool is_uids = false);
+    
+    /**
+     Fetches the flags of a message in the specified mailbox.
+    
+     @param mailbox the name of the mailbox
+     @param message_no the number of the message
+     @param flags a vector to store the found flags
+     @param is_uids whether the message number is a UID
+    
+     @throws imap_error if an IMAP error occurs
+    */    
+    void fetch_flags(const std::string& mailbox, unsigned long message_no, std::vector<std::string>& flags, bool is_uids = false);
+    /**
+     * Fetches flags for a range of messages from the mailbox.
+     *
+     * @param messages_range The range of messages to fetch flags for.
+     * @param found_flags    A map to store the fetched flags.
+     * @param is_uids        Flag indicating whether to use UIDs or not.
+     *
+     * @throws imap_error Fetching flags failure.
+     * @throws imap_error Parsing failure.
+     */
+    void fetch_flags(const std::list<messages_range_t>& messages_range, std::map<unsigned long, std::vector<std::string>>& found_flags, bool is_uids = false);
+
+    /**
     Appending a message to the given folder.
 
     @param folder_name Folder to append the message.

--- a/include/mailio/message.hpp
+++ b/include/mailio/message.hpp
@@ -59,7 +59,7 @@ Mail message and applied parsing/formatting algorithms.
 class MAILIO_EXPORT message : public mime
 {
 public:
-
+       
     /**
     Character to separate mail addresses in a list.
     **/
@@ -108,6 +108,12 @@ public:
     @todo Default implementation is probably a bug, but not manifested yet.
     **/
     message& operator=(message&&) = default;
+
+    /**
+    IMAP Flags of the message.
+
+    **/
+    std::vector<std::string> flags;
 
     /**
     Formatting the message to a string.
@@ -232,6 +238,22 @@ public:
     **/
     std::string reply_address_to_string() const;
 
+
+    /**
+     Sets or clears a specific flag.
+     
+     @param flag The flag to set or clear.
+     @param value True to set the flag, false to clear it.
+     
+     @return None
+     @throws None
+     */
+    void set_flag(const std::string &flag) {
+        if (std::find(flags.begin(), flags.end(), flag) == flags.end()) {
+            flags.emplace_back(flag);
+        }
+    }
+    
     /**
     Adding a recipent name and address.
 

--- a/src/imap.cpp
+++ b/src/imap.cpp
@@ -359,7 +359,9 @@ void imap::fetch_flags(unsigned long message_no, std::vector<std::string>& flags
     std::map<unsigned long, std::vector<std::string>> found_flags;
     messages_range.push_back(imap::messages_range_t(message_no, message_no));
     fetch_flags(messages_range, found_flags, is_uids);
-    flags = found_flags.begin()->second;
+    if (found_flags.begin() != found_flags.end()) {
+        flags = found_flags.begin()->second;
+    }
 }
 
 void imap::fetch_flags(const std::string& mailbox, unsigned long message_no, std::vector<std::string>& flags, bool is_uids) {

--- a/src/imap.cpp
+++ b/src/imap.cpp
@@ -354,6 +354,102 @@ void imap::fetch(unsigned long message_no, message& msg, bool is_uid, bool heade
 }
 
 
+void imap::fetch_flags(unsigned long message_no, std::vector<std::string>& flags, bool is_uids) {
+    std::list<messages_range_t> messages_range;
+    std::map<unsigned long, std::vector<std::string>> found_flags;
+    messages_range.push_back(imap::messages_range_t(message_no, message_no));
+    fetch_flags(messages_range, found_flags, is_uids);
+    flags = found_flags.begin()->second;
+}
+
+void imap::fetch_flags(const std::string& mailbox, unsigned long message_no, std::vector<std::string>& flags, bool is_uids) {
+    select(mailbox);
+    fetch_flags(message_no, flags, is_uids);
+}
+
+void imap::fetch_flags(const std::list<messages_range_t>& messages_range, std::map<unsigned long, std::vector<std::string>>& found_flags, bool is_uids)
+{
+    if (messages_range.empty()) {
+        throw imap_error("Empty messages range.");
+    }
+
+    string cmd;
+    if (is_uids) {
+        cmd.append("UID ");
+    }
+
+    cmd.append("FETCH " + messages_range_list_to_string(messages_range) + TOKEN_SEPARATOR_STR + "(FLAGS)");
+    dlg_->send(format(cmd));
+
+    bool has_more = true;
+    try
+    {
+        while (has_more)
+        {
+            reset_response_parser();
+            string line = dlg_->receive();
+            tag_result_response_t parsed_line = parse_tag_result(line);
+
+            if (parsed_line.tag == UNTAGGED_RESPONSE)
+            {
+                parse_response(parsed_line.response);
+
+                if (mandatory_part_.empty() || mandatory_part_.front()->token_type != response_token_t::token_type_t::ATOM) {
+                    throw imap_error("Fetching message failure.");
+                }
+
+                unsigned long msg_no = stoul(mandatory_part_.front()->atom);
+                mandatory_part_.pop_front();
+
+                if (msg_no == 0) {
+                    throw imap_error("Invalid message number.");
+                }
+
+                if (mandatory_part_.empty() || !iequals(mandatory_part_.front()->atom, "FETCH")) {
+                    throw imap_error("Fetching message failure.");
+                }
+
+                mandatory_part_.pop_front();
+
+                if (mandatory_part_.empty() || mandatory_part_.front()->token_type != response_token_t::token_type_t::LIST) {
+                    throw imap_error("Expected a list of flags.");
+                }
+
+                auto flag_list = mandatory_part_.front()->parenthesized_list;
+
+                for (auto it = flag_list.begin(); it != flag_list.end(); ++it) {
+                    if ((*it)->token_type == response_token_t::token_type_t::ATOM && iequals((*it)->atom, "FLAGS")) {
+                        ++it; // Move to the actual list of flags
+                        if (it != flag_list.end() && (*it)->token_type == response_token_t::token_type_t::LIST) {
+                            for (const auto& flag_token : (*it)->parenthesized_list) {
+                                if (flag_token->token_type == response_token_t::token_type_t::ATOM) {
+                                    found_flags[msg_no].emplace_back(flag_token->atom);
+                                }
+                            }
+                        }
+                        break; // Once FLAGS are found and processed, we break out of the loop
+                    }
+                }
+            }
+            else if (parsed_line.tag == to_string(tag_))
+            {
+                if (parsed_line.result.value() != tag_result_response_t::OK) {
+                    throw imap_error("Fetching flags failed.");
+                }
+                has_more = false;
+            }
+            else
+            {
+                throw imap_error("Unexpected response during flags fetch.");
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        throw imap_error(std::string("Parsing failure: ") + e.what());
+    }
+    reset_response_parser();
+}
 // Fetching literal is the only place where line is ended with LF only, instead of CRLF. Thus, `receive(true)` and counting EOLs is performed.
 void imap::fetch(const list<messages_range_t>& messages_range, map<unsigned long, message>& found_messages, bool is_uids, bool header_only,
     codec::line_len_policy_t line_policy)
@@ -367,11 +463,12 @@ void imap::fetch(const list<messages_range_t>& messages_range, map<unsigned long
     string cmd;
     if (is_uids)
         cmd.append("UID ");
-    cmd.append("FETCH " + message_ids + TOKEN_SEPARATOR_STR + RFC822_TOKEN);
+    cmd.append("FETCH " + message_ids + TOKEN_SEPARATOR_STR + "(" + RFC822_TOKEN + TOKEN_SEPARATOR_STR + "FLAGS)");
     dlg_->send(format(cmd));
 
     // Stores messages as string literals for parsing after the OK response.
     map<unsigned long, string> msg_str;
+    list<string> flags;
     bool has_more = true;
     try
     {
@@ -415,7 +512,14 @@ void imap::fetch(const list<messages_range_t>& messages_range, map<unsigned long
                                     if (token == part->parenthesized_list.end() || (*token)->token_type != response_token_t::token_type_t::LITERAL)
                                         throw imap_error("Parsing failure.");
                                     literal_token = *token;
-                                    break;
+                                }
+                                else if (iequals((*token)->atom, "FLAGS"))
+                                {
+                                    token++;
+                                    if (token == part->parenthesized_list.end() || (*token)->token_type != response_token_t::token_type_t::LIST)
+                                        throw imap_error("Parsing failure.");
+                                    for (auto flag_token : (*token)->parenthesized_list)
+                                        flags.push_back(flag_token->atom);
                                 }
                             }
 
@@ -457,6 +561,9 @@ void imap::fetch(const list<messages_range_t>& messages_range, map<unsigned long
                         message msg;
                         msg.line_policy(line_policy, line_policy);
                         msg.parse(ms.second);
+                        for (const auto& flag : flags) {
+                            msg.set_flag(flag);
+                        }
                         found_messages.emplace(ms.first, move(msg));
                     }
                 }


### PR DESCRIPTION
I added a new fetch_flags method to the imap class, specifically for retrieving only the IMAP flags of messages. Additionally, I modified the original fetch method so that it now requests the flags from the server when fetching the message. I added a std::vector<std::string> element called flags that stores the flags received from the server in their original format (e.g., \Seen). This implementation also supports custom flags.