### PR TITLE
Allow external initialisation of the SSL context for smtps

### DIFF
--- a/include/mailio/dialog.hpp
+++ b/include/mailio/dialog.hpp
@@ -196,6 +196,7 @@ Secure version of `dialog` class.
 class dialog_ssl : public dialog
 {
 public:
+    using ssl_context = boost::asio::ssl::context;
 
     /**
     SSL options to set on a socket.
@@ -231,6 +232,14 @@ public:
     @param options SSL options to set.
     **/
     dialog_ssl(const dialog& other, const ssl_options_t& options);
+
+    /**
+    Calling the parent constructor, initializing the SSL socket.
+
+    @param other   Plain connection to use for the SSL.
+    @param options SSL context to use.
+    **/
+    dialog_ssl(const dialog& other, std::shared_ptr<ssl_context> context);
 
     /**
     Default copy constructor.

--- a/include/mailio/smtp.hpp
+++ b/include/mailio/smtp.hpp
@@ -272,10 +272,11 @@ public:
     @param username Username to authenticate.
     @param password Password to authenticate.
     @param method   Authentication method to use.
+    @param ssl_context The SSL context to use for the socket.
     @return         The server greeting message.
     @throw *        `start_tls()`, `switch_to_ssl()`, `ehlo()`, `auth_login(const string&, const string&)`, `connect()`.
     **/
-    std::string authenticate(const std::string& username, const std::string& password, auth_method_t method);
+    std::string authenticate(const std::string& username, const std::string& password, auth_method_t method, std::shared_ptr<dialog_ssl::ssl_context> ssl_context = nullptr);
 
     /**
     Setting SSL options.
@@ -292,14 +293,14 @@ protected:
     @throw smtp_error Start TLS refused by server.
     @throw *          `parse_line(const string&)`, `ehlo()`, `dialog::send(const string&)`, `dialog::receive()`, `switch_to_ssl()`.
     **/
-    void start_tls();
+    void start_tls(std::shared_ptr<dialog_ssl::ssl_context> ssl_context);
 
     /**
     Replacing a TCP socket with an SSL one.
 
     @throw * `dialog_ssl::dialog_ssl(dialog&, const ssl_options_t&)`.
     **/
-    void switch_to_ssl();
+    void switch_to_ssl(std::shared_ptr<dialog_ssl::ssl_context> ssl_context);
 
     /**
     SSL options to set.

--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -253,6 +253,22 @@ dialog_ssl::dialog_ssl(const dialog& other, const ssl_options_t& options) : dial
 }
 
 
+dialog_ssl::dialog_ssl(const dialog& other, shared_ptr<ssl_context> context) : dialog(other), context_(context),
+    ssl_socket_(make_shared<boost::asio::ssl::stream<tcp::socket&>>(*socket_, *context_))
+{
+    try
+    {
+        ssl_socket_->handshake(boost::asio::ssl::stream_base::client);
+        ssl_ = true;
+    }
+    catch (system_error&)
+    {
+        // TODO: perhaps the message is confusing
+        throw dialog_error("Switching to SSL failed.");
+    }
+}
+
+
 void dialog_ssl::send(const string& line)
 {
     if (!ssl_)


### PR DESCRIPTION
fixes karastojko/mailio#173

These are the changes for the smtps class that allow for the creation and initialisation of an SSL context externally to the library so that users can setup their SSL certificates or other settings that are not accessible when the context is kept private.

The default was also changed to use peer verification by default.

These changes should be easy to also apply to the other classes that need them.