### PR TITLE
Prevent range-error by checking whether subject exists before formatting it

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -573,7 +573,8 @@ string message::format_header(bool add_bcc_header) const
         header += MIME_VERSION_HEADER + HEADER_SEPARATOR_STR + version_ + codec::END_OF_LINE;
     header += mime::format_header();
 
-    header += SUBJECT_HEADER + HEADER_SEPARATOR_STR + format_subject() + codec::END_OF_LINE;
+    if (!subject_.buffer.empty())
+        header += SUBJECT_HEADER + HEADER_SEPARATOR_STR + format_subject() + codec::END_OF_LINE;
 
     return header;
 }

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -141,6 +141,21 @@ BOOST_AUTO_TEST_CASE(format_no_sender_two_authors)
     BOOST_CHECK_THROW(msg.format(msg_str), message_error);
 }
 
+/**
+Formatting a message without a subject.
+
+@pre  None.
+@post None.
+**/
+BOOST_AUTO_TEST_CASE(format_no_subject)
+{
+    message msg;
+    msg.from(mail_address("mailio", "adresa@mailio.dev"));
+    msg.add_recipient(mail_address("mailio", "adresa@mailio.dev"));
+    string msg_str;
+    BOOST_CHECK_NO_THROW(msg.format(msg_str));
+}
+
 
 /**
 Formatting other headers.


### PR DESCRIPTION
Hi @karastojko,

Thank you for the library 💯 

We were recently updating mailio and it seems that previously formatting a mail without a subject works, but throws an error now. Here is the code where the error originates:

```cpp
string message::format_subject() const
    ...
    if (subject_.codec_type == codec::codec_t::ASCII)
    {
        bit7 b7(line1_policy, line_policy);
        vector<string> hdr = b7.encode(subject_.buffer);
        subject += hdr.at(0) + codec::END_OF_LINE;
        subject += fold_header_line(hdr);
    }
```
Judging by a quick look, I think when subject_.buffer is empty, b7.encode will return an empty vector, causing hdr.at(0) to throw an out-of-range error.

We are only creating messages without a subject in tests. Afaik sending mails without a subject is allowed, so I think the library should support that. I can totally understand if you disagree, as sending mails without a subject is not best practice. However then I would have expected the library to error with a specific error message.

Thank you for taking your time and this awesome library 🙏🏻 