### PR TITLE
Fix for EHLO not being sent after STARTTLS

### DIFF
--- a/src/smtp.cpp
+++ b/src/smtp.cpp
@@ -74,8 +74,11 @@ string smtp::authenticate(const string& username, const string& password, auth_m
 
     string greeting = connect();
     ehlo();
-    if (is_start_tls_)
+    if (is_start_tls_) 
+    {
         switch_tls();
+        ehlo();
+    }
 
     if (method == auth_method_t::NONE)
         ;


### PR DESCRIPTION
Client should send EHLO after STARTTLS command. You can reproduce this issue by configuring exim4 to allow AUTH only on TLS secured connection. After STARTTLS, client should send another EHLO to allow server advertise new capabilities.