### PR TITLE
Fix stale async handler after timeout

### DIFF
--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -222,7 +222,7 @@ void dialog::wait_async(const bool& has_op, const bool& op_error, const char* ex
             // handlers firing later with dangling references on the shared
             // socket when a dialog copy is made.
             boost::system::error_code ec;
-            socket_->cancel(ec);
+            std::ignore = socket_->cancel(ec);
             timer_->cancel();
             while (ios_.poll_one())
                 ;
@@ -231,7 +231,7 @@ void dialog::wait_async(const bool& has_op, const bool& op_error, const char* ex
         if (op_error)
         {
             boost::system::error_code ec;
-            socket_->cancel(ec);
+            std::ignore = socket_->cancel(ec);
             timer_->cancel();
             while (ios_.poll_one())
                 ;

--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -136,18 +136,23 @@ void dialog::connect_async()
     tcp::resolver res(ios_);
     check_timeout();
 
-    bool has_connected{false}, connect_error{false};
-    error_code errc;
+    struct SharedState
+    {
+        bool has_connected{false};
+        bool connect_error{false};
+        error_code errc;
+    };
+    auto state = std::make_shared<SharedState>();
     async_connect(*socket_, res.resolve(hostname_, to_string(port_)),
-        [&has_connected, &connect_error, &errc](const error_code& error, const boost::asio::ip::tcp::endpoint&)
+        [state](const error_code& error, const boost::asio::ip::tcp::endpoint&)
         {
             if (!error)
-                has_connected = true;
+                state->has_connected = true;
             else
-                connect_error = true;
-            errc = error;
+                state->connect_error = true;
+            state->errc = error;
         });
-    wait_async(has_connected, connect_error, "Network connecting timed out.", "Network connecting failed.", errc);
+    wait_async(state->has_connected, state->connect_error, "Network connecting timed out.", "Network connecting failed.", state->errc);
 }
 
 
@@ -156,18 +161,23 @@ void dialog::send_async(Socket& socket, string line)
 {
     check_timeout();
     string l = line + "\r\n";
-    bool has_written{false}, send_error{false};
-    error_code errc;
+    struct SharedState
+    {
+        bool has_written{false};
+        bool send_error{false};
+        error_code errc;
+    };
+    auto state = std::make_shared<SharedState>();
     async_write(socket, buffer(l, l.size()),
-        [&has_written, &send_error, &errc](const error_code& error, size_t)
+        [state](const error_code& error, size_t)
         {
             if (!error)
-                has_written = true;
+                state->has_written = true;
             else
-                send_error = true;
-            errc = error;
+                state->send_error = true;
+            state->errc = error;
         });
-    wait_async(has_written, send_error, "Network sending timed out.", "Network sending failed.", errc);
+    wait_async(state->has_written, state->send_error, "Network sending timed out.", "Network sending failed.", state->errc);
 }
 
 
@@ -175,25 +185,30 @@ template<typename Socket>
 string dialog::receive_async(Socket& socket, bool raw)
 {
     check_timeout();
-    bool has_read{false}, receive_error{false};
-    string line;
-    error_code errc;
+    struct SharedState
+    {
+        bool has_read{false};
+        bool receive_error{false};
+        string line;
+        error_code errc;
+    };
+    auto state = std::make_shared<SharedState>();
     async_read_until(socket, *strmbuf_, "\n",
-        [&has_read, &receive_error, this, &line, &errc, raw](const error_code& error, size_t)
+        [state, this, raw](const error_code& error, size_t)
         {
             if (!error)
             {
-                getline(*istrm_, line, '\n');
+                getline(*istrm_, state->line, '\n');
                 if (!raw)
-                    trim_if(line, is_any_of("\r\n"));
-                has_read = true;
+                    trim_if(state->line, is_any_of("\r\n"));
+                state->has_read = true;
             }
             else
-                receive_error = true;
-            errc = error;
+                state->receive_error = true;
+            state->errc = error;
         });
-    wait_async(has_read, receive_error, "Network receiving timed out.", "Network receiving failed.", errc);
-    return line;
+    wait_async(state->has_read, state->receive_error, "Network receiving timed out.", "Network receiving failed.", state->errc);
+    return state->line;
 }
 
 
@@ -202,10 +217,28 @@ void dialog::wait_async(const bool& has_op, const bool& op_error, const char* ex
     do
     {
         if (timer_expired_)
+        {
+            // Drain any pending handlers before throwing, to avoid stale
+            // handlers firing later with dangling references on the shared
+            // socket when a dialog copy is made.
+            boost::system::error_code ec;
+            socket_->cancel(ec);
+            timer_->cancel();
+            while (ios_.poll_one())
+                ;
             throw dialog_error(expired_msg, error.message());
+        }
         if (op_error)
+        {
+            boost::system::error_code ec;
+            socket_->cancel(ec);
+            timer_->cancel();
+            while (ios_.poll_one())
+                ;
             throw dialog_error(op_msg, error.message());
-        ios_.run_one();
+        }
+        if (!ios_.run_one())
+            ios_.restart();
     }
     while (!has_op);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Dependencies
 find_package("Boost" REQUIRED COMPONENTS "unit_test_framework")
+find_package("Boost" COMPONENTS "system")
+find_package("Threads" REQUIRED)
 
 # Makes a new target for each test file.
 function(make_test test_file)
@@ -27,3 +29,6 @@ file(GLOB TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 foreach(file ${TEST_FILES})
     make_test("${file}")
 endforeach()
+
+target_link_libraries("test_dialog_stale_handler" PRIVATE "Boost::system")
+target_link_libraries("test_dialog_stale_handler" PRIVATE "Threads::Threads")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,5 @@
 # Dependencies
 find_package("Boost" REQUIRED COMPONENTS "unit_test_framework")
-find_package("Boost" COMPONENTS "system")
 find_package("Threads" REQUIRED)
 
 # Makes a new target for each test file.
@@ -30,5 +29,4 @@ foreach(file ${TEST_FILES})
     make_test("${file}")
 endforeach()
 
-target_link_libraries("test_dialog_stale_handler" PRIVATE "Boost::system")
 target_link_libraries("test_dialog_stale_handler" PRIVATE "Threads::Threads")

--- a/test/test_dialog_stale_handler.cpp
+++ b/test/test_dialog_stale_handler.cpp
@@ -1,0 +1,119 @@
+/*
+test_dialog_stale_handler.cpp
+-----------------------------
+
+Copyright (C) 2016, Tomislav Karastojkovic (http://www.alepho.com).
+
+Distributed under the FreeBSD license, see the accompanying file LICENSE or
+copy at http://www.freebsd.org/copyright/freebsd-license.html.
+*/
+
+
+#define BOOST_TEST_MODULE dialog_test
+
+#include <boost/test/unit_test.hpp>
+#include <boost/asio.hpp>
+#include <mailio/dialog.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+
+using boost::asio::ip::tcp;
+using std::chrono::milliseconds;
+using namespace std::chrono_literals;
+
+
+// A minimal TCP server that accepts one connection and optionally sends data
+// after a delay.  Used to simulate a slow server that triggers a timeout.
+class TestServer
+{
+public:
+    TestServer(unsigned short port)
+        : work_(io_.get_executor()), acceptor_(io_, tcp::endpoint(tcp::v4(), port))
+    {
+    }
+
+    void start()
+    {
+        thread_ = std::thread([this] {
+            auto socket = std::make_shared<tcp::socket>(io_);
+            acceptor_.async_accept(*socket, [this, socket](boost::system::error_code ec) {
+                if (!ec)
+                    socket_ = socket;
+            });
+            io_.run();
+        });
+    }
+
+    void send_after(milliseconds delay, const std::string& msg)
+    {
+        boost::asio::post(io_, [this, delay, msg] {
+            auto timer = std::make_shared<boost::asio::steady_timer>(io_, delay);
+            timer->async_wait([this, timer, msg](boost::system::error_code ec) {
+                if (!ec && socket_ && socket_->is_open())
+                    boost::asio::async_write(*socket_, boost::asio::buffer(msg),
+                        [](boost::system::error_code, size_t) {});
+            });
+        });
+    }
+
+    void stop()
+    {
+        boost::system::error_code ec;
+        if (socket_ && socket_->is_open())
+            socket_->close(ec);
+        io_.stop();
+        if (thread_.joinable())
+            thread_.join();
+    }
+
+private:
+    boost::asio::io_context                                                  io_;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_;
+    tcp::acceptor                                                            acceptor_;
+    std::shared_ptr<tcp::socket>                                             socket_;
+    std::thread                                                              thread_;
+};
+
+
+BOOST_AUTO_TEST_SUITE(test_dialog_stale_handler)
+
+
+BOOST_AUTO_TEST_CASE(timeout_then_copy_then_receive)
+{
+    const unsigned short PORT = 22125;
+
+    TestServer server(PORT);
+    server.start();
+    std::this_thread::sleep_for(100ms);
+
+    // Step 1: create a dialog with a short timeout and connect.
+    auto dlg1 = std::make_shared<mailio::dialog>("127.0.0.1", PORT, 100ms);
+    dlg1->connect();
+
+    // Step 2: receive() will time out because the server hasn't sent data yet.
+    // Before the fix, this left a stale async_read_until handler on the shared
+    // static io_context, which would crash on the next receive().
+    BOOST_CHECK_THROW(dlg1->receive(), mailio::dialog_error);
+
+    // Step 3: copy the dialog.  The copy shares the socket/timer/streambuf.
+    auto dlg2 = std::make_shared<mailio::dialog>(*dlg1);
+    dlg1.reset();
+
+    // Step 4: server sends data.
+    server.send_after(50ms, "220 test\r\n");
+
+    // Step 5: receive on the copy.  Before the fix this would either crash
+    // (stale handler writing to freed stack memory) or hang (io_context stuck
+    // in stopped state).  After the fix it should succeed.
+    std::string line = dlg2->receive();
+    BOOST_CHECK_EQUAL(line, "220 test");
+
+    server.stop();
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_dialog_stale_handler.cpp
+++ b/test/test_dialog_stale_handler.cpp
@@ -14,12 +14,12 @@ copy at http://www.freebsd.org/copyright/freebsd-license.html.
 #include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_suite.hpp>
 #include <boost/test/tools/old/interface.hpp>
-#include <boost/asio.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/steady_timer.hpp>
-#include <boost/system/error_code.hpp>
+#include <boost/system/detail/error_code.hpp>
 #include <mailio/dialog.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -45,7 +45,7 @@ public:
     {
         thread_ = std::thread([this] {
             auto socket = std::make_shared<tcp::socket>(io_);
-            acceptor_.async_accept(*socket, [this, socket](boost::system::error_code ec) {
+            acceptor_.async_accept(*socket, [this, socket](const boost::system::error_code ec) {
                 if (!ec)
                 {
                     socket_ = socket;
@@ -59,7 +59,7 @@ public:
     {
         boost::asio::post(io_, [this, delay, msg] {
             auto timer = std::make_shared<boost::asio::steady_timer>(io_, delay);
-            timer->async_wait([this, timer, msg](boost::system::error_code ec) {
+            timer->async_wait([this, timer, msg](const boost::system::error_code ec) {
                 if (!ec && socket_ && socket_->is_open())
                 {
                     boost::asio::async_write(*socket_, boost::asio::buffer(msg),
@@ -71,10 +71,11 @@ public:
 
     void stop()
     {
-        boost::system::error_code ec;
         if (socket_ && socket_->is_open())
         {
-            static_cast<void>(socket_->close(ec));
+            boost::system::error_code ec;
+            socket_->close(ec);
+            BOOST_CHECK(!ec.failed());
         }
         io_.stop();
         if (thread_.joinable())

--- a/test/test_dialog_stale_handler.cpp
+++ b/test/test_dialog_stale_handler.cpp
@@ -2,7 +2,7 @@
 test_dialog_stale_handler.cpp
 -----------------------------
 
-Copyright (C) 2016, Tomislav Karastojkovic (http://www.alepho.com).
+Copyright (C) 2026, Tomislav Karastojkovic (http://www.alepho.com).
 
 Distributed under the FreeBSD license, see the accompanying file LICENSE or
 copy at http://www.freebsd.org/copyright/freebsd-license.html.
@@ -12,12 +12,17 @@ copy at http://www.freebsd.org/copyright/freebsd-license.html.
 #define BOOST_TEST_MODULE dialog_test
 
 #include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+#include <boost/test/tools/old/interface.hpp>
 #include <boost/asio.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/system/error_code.hpp>
 #include <mailio/dialog.hpp>
 
-#include <chrono>
-#include <iostream>
+#include <cstddef>
 #include <memory>
+#include <string>
 #include <thread>
 
 
@@ -31,7 +36,7 @@ using namespace std::chrono_literals;
 class TestServer
 {
 public:
-    TestServer(unsigned short port)
+    explicit TestServer(unsigned short port)
         : work_(io_.get_executor()), acceptor_(io_, tcp::endpoint(tcp::v4(), port))
     {
     }
@@ -42,7 +47,9 @@ public:
             auto socket = std::make_shared<tcp::socket>(io_);
             acceptor_.async_accept(*socket, [this, socket](boost::system::error_code ec) {
                 if (!ec)
+                {
                     socket_ = socket;
+                }
             });
             io_.run();
         });
@@ -54,8 +61,10 @@ public:
             auto timer = std::make_shared<boost::asio::steady_timer>(io_, delay);
             timer->async_wait([this, timer, msg](boost::system::error_code ec) {
                 if (!ec && socket_ && socket_->is_open())
+                {
                     boost::asio::async_write(*socket_, boost::asio::buffer(msg),
-                        [](boost::system::error_code, size_t) {});
+                        [](boost::system::error_code, std::size_t) {});
+                }
             });
         });
     }
@@ -64,10 +73,14 @@ public:
     {
         boost::system::error_code ec;
         if (socket_ && socket_->is_open())
-            socket_->close(ec);
+        {
+            static_cast<void>(socket_->close(ec));
+        }
         io_.stop();
         if (thread_.joinable())
+        {
             thread_.join();
+        }
     }
 
 private:

--- a/test/test_dialog_stale_handler.cpp
+++ b/test/test_dialog_stale_handler.cpp
@@ -74,8 +74,7 @@ public:
         if (socket_ && socket_->is_open())
         {
             boost::system::error_code ec;
-            socket_->close(ec);
-            BOOST_CHECK(!ec.failed());
+            BOOST_CHECK(!socket_->close(ec));
         }
         io_.stop();
         if (thread_.joinable())


### PR DESCRIPTION
Cancel socket and drain pending handlers before throwing in wait_async(), preventing use-after-free when dialog is copied

Fix: #223, maybe #222 too